### PR TITLE
Imporvements multi bit channel

### DIFF
--- a/FORMAT_SPECIFICATION.md
+++ b/FORMAT_SPECIFICATION.md
@@ -1,0 +1,295 @@
+# Steganography Format Specification
+
+This document describes the container format used by `steg` to store encoded data within images. It covers both the current format (Version 0) and the planned format with nonce support (Version 1).
+
+## Overview
+
+The steganographic data is stored in a container format within the image's pixel data. The format includes:
+- Length information (to know how much data to read)
+- The actual payload (encrypted)
+- A checksum for integrity verification
+
+All data is written bit-by-bit into the least significant bits (LSBs) of the image pixels, making the changes virtually imperceptible to the human eye.
+
+## Format Version 0 (Current - Backward Compatible)
+
+**Status**: Currently in use (default)
+
+### Layout
+
+```
+┌─────────────────┬──────────┬──────────────┐
+│  Length (4 B)   │  Payload │  Checksum    │
+│  (uint32 LE)    │  (N B)   │  (16 B MD5)  │
+└─────────────────┴──────────┴──────────────┘
+```
+
+### Byte Structure
+
+1. **Length (4 bytes, little-endian uint32)**
+   - Encrypted using AES-CTR stream cipher
+   - Specifies the size of the payload in bytes
+
+2. **Payload (N bytes)**
+   - The actual data being hidden
+   - Encrypted using AES-CTR stream cipher
+   - Size determined by the length field
+
+3. **Checksum (16 bytes)**
+   - MD5 hash of the decrypted payload
+   - Encrypted using AES-CTR stream cipher
+   - Used to verify data integrity and correct decryption
+
+### Encryption Details
+
+- **Cipher**: AES in CTR mode (stream cipher)
+- **Nonce**: Fixed value of `0` (security limitation)
+- **Key derivation**: PKCS#7 padded password → AES key
+- **Stream position**: The cipher uses the bit position within the stream as part of the counter
+
+### Example
+
+For a payload of `"hello"` (5 bytes):
+
+```
+[05 00 00 00] [encrypted "hello"] [16 encrypted MD5 bytes]
+   ↑              ↑                      ↑
+ Length        Payload              Checksum
+```
+
+### Total Size
+
+- **Minimum**: 4 (length) + 0 (empty payload) + 16 (MD5) = **20 bytes**
+- **Maximum**: Depends on image capacity (width × height × channels × bits_per_channel)
+
+---
+
+## Format Version 1 (Planned - With Nonce Support)
+
+**Status**: Infrastructure ready, but not yet activated (maintains backward compatibility)
+
+### Layout
+
+```
+┌────────┬───────────┬───────────┬──────────┬──────────────┐
+│ Nonce  │  Version  │  Length   │ Payload  │  Checksum    │
+│ (4 B)  │   (1 B)   │  (4 B)    │  (N B)   │  (16 B MD5)  │
+│        │           │ uint32 LE │          │              │
+└────────┴───────────┴───────────┴──────────┴──────────────┘
+   ↑         ↑          ↑           ↑           ↑
+ Unencrypted Encrypted  Encrypted   Encrypted   Encrypted
+```
+
+### Byte Structure
+
+1. **Nonce (4 bytes, unencrypted)**
+   - Cryptographically secure random 32-bit value
+   - Generated using `crypto/rand`
+   - Stored **unencrypted** at the start (needed to initialize cipher)
+   - Little-endian format
+
+2. **Version (1 byte)**
+   - Format version identifier
+   - Value: `0x01` for Version 1
+   - Encrypted using AES-CTR stream cipher (position starts after nonce)
+
+3. **Length (4 bytes, little-endian uint32)**
+   - Encrypted using AES-CTR stream cipher
+   - Specifies the size of the payload in bytes
+   - Cipher position continues from version byte
+
+4. **Payload (N bytes)**
+   - The actual data being hidden
+   - Encrypted using AES-CTR stream cipher
+   - Size determined by the length field
+
+5. **Checksum (16 bytes)**
+   - MD5 hash of the decrypted payload
+   - Encrypted using AES-CTR stream cipher
+   - Used to verify data integrity and correct decryption
+
+### Encryption Details
+
+- **Cipher**: AES in CTR mode (stream cipher)
+- **Nonce**: **Random per encoding session** (security improvement)
+- **Key derivation**: PKCS#7 padded password → AES key
+- **Stream position**: The cipher uses the bit position within the stream as part of the counter
+- **Nonce position**: Nonce is stored unencrypted at bit position 0-31 (byte 0-3)
+
+### Example
+
+For a payload of `"hello"` (5 bytes) with nonce `0x12345678`:
+
+```
+[78 56 34 12] [encrypted 0x01] [encrypted length] [encrypted "hello"] [encrypted MD5]
+     ↑              ↑                  ↑                   ↑                 ↑
+   Nonce        Version            Length             Payload          Checksum
+(unencrypted)   (encrypted)       (encrypted)        (encrypted)       (encrypted)
+```
+
+### Total Size
+
+- **Minimum**: 4 (nonce) + 1 (version) + 4 (length) + 0 (empty payload) + 16 (MD5) = **25 bytes**
+- **Maximum**: Depends on image capacity
+
+---
+
+## Key Differences
+
+| Aspect | Version 0 (Current) | Version 1 (Planned) |
+|--------|---------------------|---------------------|
+| **Nonce** | Fixed `0` | Random per encoding |
+| **Version field** | None (implicit) | 1 byte version identifier |
+| **Nonce storage** | Not stored (always 0) | Stored unencrypted at start |
+| **Security** | Lower (same nonce for all) | Higher (unique nonce per encoding) |
+| **Backward compatibility** | N/A (baseline) | Can decode Version 0 |
+| **Size overhead** | 20 bytes minimum | 25 bytes minimum (+5 bytes) |
+| **Format detection** | First 4 bytes = length | First 4 bytes = nonce, then version byte |
+
+## Security Implications
+
+### Version 0 Limitations
+
+Using a fixed nonce of `0` has security implications:
+
+1. **Replay vulnerability**: Multiple encodings with the same password produce similar ciphertext patterns
+2. **Statistical analysis**: Patterns may emerge when analyzing multiple encoded images
+3. **Reduced entropy**: The stream cipher initialization is predictable
+
+### Version 1 Benefits
+
+Using a random nonce per encoding provides:
+
+1. **Unique encryption**: Each encoding produces different ciphertext even with the same payload and password
+2. **Better security**: Follows cryptographic best practices for stream ciphers
+3. **Protection against**: Replay attacks, pattern analysis, and ciphertext comparison
+
+## Implementation Status
+
+### Current State
+
+The codebase includes:
+- ✅ Format version constants (`FormatVersion0`, `FormatVersion1`)
+- ✅ `GenerateNonce()` function for cryptographically secure nonce generation
+- ✅ `WritePayloadWithNonce()` function (infrastructure ready)
+- ✅ `ReadPayload()` function supporting Version 1 (infrastructure ready)
+- ✅ Backward compatibility layer (`ReadPayloadOldFormat()`)
+
+### Active Code
+
+Currently, the code uses:
+- `WritePayload()` - writes in Version 0 format
+- `ReadPayloadOldFormat()` - reads Version 0 format
+- Nonce value: `0` (hardcoded for compatibility)
+
+### Code Locations
+
+- **Container format**: `steg/container/container.go`
+- **Encoding**: `steg/encode.go` (uses `WritePayload()`)
+- **Decoding**: `steg/decode.go` (uses `ReadPayloadOldFormat()`)
+
+## Migration Path
+
+To activate Version 1 format:
+
+### Step 1: Update Encoding
+
+Modify `steg/encode.go`:
+```go
+// Generate random nonce
+nonce, err := container.GenerateNonce()
+if err != nil {
+    return fmt.Errorf("failed to generate nonce: %w", err)
+}
+
+// Write nonce unencrypted first
+adapterNoCipher := cursors.CursorAdapter(cur)
+nonceBytes := make([]byte, 4)
+binary.LittleEndian.PutUint32(nonceBytes, nonce)
+if _, err := adapterNoCipher.Write(nonceBytes); err != nil {
+    return fmt.Errorf("failed to write nonce: %w", err)
+}
+
+// Create cipher middleware with the generated nonce
+cm := cursors.CipherMiddleware(cur, cipher.NewCipher(nonce, pass))
+_, err = cm.Seek(32, 0) // Seek to position after nonce (32 bits = 4 bytes)
+if err != nil {
+    return fmt.Errorf("failed to seek cipher: %w", err)
+}
+
+adapter := cursors.CursorAdapter(cm)
+return container.WritePayloadWithNonce(adapter, bytes.NewReader(payloadData), hashFn, nonce)
+```
+
+### Step 2: Update Decoding
+
+Modify `steg/decode.go`:
+```go
+// Read nonce unencrypted from first 4 bytes
+adapterNoCipher := cursors.CursorAdapter(cur)
+nonceBytes := make([]byte, 4)
+_, err = adapterNoCipher.Read(nonceBytes)
+if err != nil {
+    // Fallback to Version 0 (try nonce=0)
+    return decodeVersion0(m, pass)
+}
+nonce := binary.LittleEndian.Uint32(nonceBytes)
+
+// Create cipher middleware with the extracted nonce
+cm := cursors.CipherMiddleware(cur, cipher.NewCipher(nonce, pass))
+_, err = cm.Seek(32, 0) // Seek to position after nonce
+if err != nil {
+    return nil, fmt.Errorf("failed to seek cipher: %w", err)
+}
+
+adapter := cursors.CursorAdapter(cm)
+payload, _, err := container.ReadPayload(adapter, md5.New())
+// ... handle errors and fallback to Version 0
+```
+
+### Step 3: Update Capacity Calculation
+
+Modify `container.CalculateRequiredCapacity()` to account for the nonce:
+```go
+func CalculateRequiredCapacity(payloadSize int64, hashSize int) int64 {
+    // Version 1: 4 (nonce) + 1 (version) + 4 (length) + payload + checksum
+    return 4 + 1 + 4 + payloadSize + int64(hashSize)
+}
+```
+
+### Step 4: Testing
+
+- Test encoding/decoding with Version 1
+- Test backward compatibility (decoding Version 0 images)
+- Test format detection and fallback logic
+- Update tests to cover both formats
+
+## Compatibility Considerations
+
+### Version Detection
+
+When reading:
+1. Read first 4 bytes (could be nonce or length)
+2. Try to read version byte
+3. If version byte exists and equals `0x01` → Version 1
+4. If no version byte or value doesn't match → Version 0 (fallback)
+
+### Backward Compatibility
+
+- **Version 1 decoder must** be able to decode Version 0 images
+- **Version 0 decoder cannot** decode Version 1 images (won't have nonce)
+- **Migration strategy**: Keep both decoders active, detect format automatically
+
+## Future Enhancements
+
+Potential improvements:
+- Format version 2: Support for different hash algorithms (not just MD5)
+- Format version 3: Support for different encryption algorithms
+- Format version 4: Metadata header (encoding date, tool version, etc.)
+
+## References
+
+- Container format implementation: `steg/container/container.go`
+- Cipher implementation: `cipher/cipher.go`
+- Encoding logic: `steg/encode.go`
+- Decoding logic: `steg/decode.go`

--- a/cmd/steg/root.go
+++ b/cmd/steg/root.go
@@ -7,6 +7,7 @@ import (
 	"image/draw"
 	"os"
 
+	"github.com/pableeee/steg/cursors"
 	"github.com/pableeee/steg/steg"
 	"github.com/pableeee/steg/steg/imageio"
 	"github.com/spf13/cobra"
@@ -48,6 +49,20 @@ var (
 		outputFile,
 		key string
 	}{}
+
+	capacityCmd = &cobra.Command{
+		Use:   "capacity",
+		Short: "Shows the encoding capacity of an image",
+		Long:  "Shows the encoding capacity of an image in bytes. This indicates how much data can be encoded into the image.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCapacity()
+		},
+	}
+
+	capacityFlags = struct {
+		inputImage string
+		bitsPerChannel int
+	}{}
 )
 
 func init() {
@@ -73,8 +88,17 @@ func init() {
 	decodeCmd.Flags().StringVarP(
 		&decoderFlags.key, "password", "p", "YELLOW SUBMARINE", "passphrase to extract the contents.",
 	)
+
+	capacityCmd.Flags().StringVarP(
+		&capacityFlags.inputImage, "input_image", "i", "", "Input image to check capacity.",
+	)
+	capacityCmd.Flags().IntVarP(
+		&capacityFlags.bitsPerChannel, "bits_per_channel", "b", 1, "Number of bits per channel to use (1-3, default: 1).",
+	)
+
 	rootCmd.AddCommand(encodeCmd)
 	rootCmd.AddCommand(decodeCmd)
+	rootCmd.AddCommand(capacityCmd)
 }
 
 func toDrawImage(src image.Image) draw.Image {
@@ -170,6 +194,73 @@ func runDecode() error {
 
 	if _, err = out.Write(b); err != nil {
 		return fmt.Errorf("failed to write output file: %w", err)
+	}
+
+	return nil
+}
+
+func runCapacity() error {
+	// Open input image
+	f, err := os.Open(capacityFlags.inputImage)
+	if err != nil {
+		return fmt.Errorf("failed to open input image: %w", err)
+	}
+	defer f.Close()
+
+	// Detect and decode image format
+	src, format, err := imageio.DecodeImage(capacityFlags.inputImage, bufio.NewReader(f))
+	if err != nil {
+		return fmt.Errorf("failed to decode image: %w", err)
+	}
+
+	cimg := toDrawImage(src)
+
+	// Validate bits per channel
+	if capacityFlags.bitsPerChannel < 1 || capacityFlags.bitsPerChannel > 3 {
+		return fmt.Errorf("bits per channel must be between 1 and 3, got: %d", capacityFlags.bitsPerChannel)
+	}
+
+	// Create RNG cursor with same options as encoding (G and B channels)
+	cur := cursors.NewRNGCursor(
+		cimg,
+		cursors.UseGreenBit(),
+		cursors.UseBlueBit(),
+		cursors.WithBitsPerChannel(capacityFlags.bitsPerChannel),
+	)
+
+	// Get capacity in bits
+	capacityBits := cur.Capacity()
+	capacityBytes := capacityBits / 8
+	
+	// Calculate usable capacity (accounting for container overhead)
+	// Format overhead: 4 bytes (length) + 16 bytes (MD5 checksum) = 20 bytes
+	containerOverhead := int64(20)
+	usableBytes := capacityBytes - containerOverhead
+	if usableBytes < 0 {
+		usableBytes = 0
+	}
+
+	// Display results
+	fmt.Printf("Image: %s\n", capacityFlags.inputImage)
+	fmt.Printf("Format: %s\n", format)
+	fmt.Printf("Dimensions: %d x %d pixels\n", cimg.Bounds().Dx(), cimg.Bounds().Dy())
+	fmt.Printf("Channels used: Green, Blue (2 channels)\n")
+	fmt.Printf("Bits per channel: %d\n", capacityFlags.bitsPerChannel)
+	fmt.Printf("\n")
+	fmt.Printf("Total capacity: %d bits (%d bytes)\n", capacityBits, capacityBytes)
+	fmt.Printf("Container overhead: %d bytes (length + checksum)\n", containerOverhead)
+	fmt.Printf("Usable capacity: %d bytes\n", usableBytes)
+	
+	// Display in human-readable format
+	if usableBytes > 0 {
+		fmt.Printf("\n")
+		if usableBytes >= 1024*1024 {
+			fmt.Printf("  ≈ %.2f MB\n", float64(usableBytes)/(1024*1024))
+		} else if usableBytes >= 1024 {
+			fmt.Printf("  ≈ %.2f KB\n", float64(usableBytes)/1024)
+		}
+	} else {
+		fmt.Printf("\n⚠️  Image is too small to encode any data.\n")
 	}
 
 	return nil

--- a/cmd/steg/root.go
+++ b/cmd/steg/root.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"image"
 	"image/draw"
-	"image/png"
-	"log"
 	"os"
 
 	"github.com/pableeee/steg/steg"
+	"github.com/pableeee/steg/steg/imageio"
 	"github.com/spf13/cobra"
 )
 
@@ -87,65 +86,90 @@ func toDrawImage(src image.Image) draw.Image {
 }
 
 func runEncode() error {
+	// Open input image
 	f, err := os.Open(encoderFlags.inputImage)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to open input image: %w", err)
+	}
+	defer f.Close()
+
+	// Detect and decode image format
+	src, format, err := imageio.DecodeImage(encoderFlags.inputImage, bufio.NewReader(f))
+	if err != nil {
+		return fmt.Errorf("failed to decode image: %w", err)
 	}
 
-	src, err := png.Decode(bufio.NewReader(f))
-	if err != nil {
-		return err
+	// Warn about lossy formats
+	if imageio.IsLossyFormat(format) {
+		fmt.Fprintf(os.Stderr, "Warning: %s is a lossy format. Steganographic data may be corrupted.\n", format)
+		fmt.Fprintf(os.Stderr, "Consider using PNG format for better reliability.\n")
 	}
 
 	cimg := toDrawImage(src)
+	
+	// Open message file
 	fmsg, err := os.Open(encoderFlags.inputMessage)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to open message file: %w", err)
+	}
+	defer fmsg.Close()
+
+	// Encode the message
+	if err = steg.Encode(cimg, []byte(encoderFlags.key), bufio.NewReader(fmsg)); err != nil {
+		return fmt.Errorf("encoding failed: %w", err)
 	}
 
+	// Determine output format (use same as input, or detect from extension)
+	outputFormat, err := imageio.DetectImageFormat(encoderFlags.outputImage, nil)
+	if err != nil {
+		// Default to input format if we can't detect from extension
+		outputFormat = format
+	}
+
+	// Create output file
 	out, err := os.Create(encoderFlags.outputImage)
 	if err != nil {
 		return fmt.Errorf("unable to create output file: %w", err)
 	}
 	defer out.Close()
 
-	if err = steg.Encode(cimg, []byte(encoderFlags.key), bufio.NewReader(fmsg)); err != nil {
-		return err
-	}
-
-	err = png.Encode(out, cimg)
-	if err != nil {
-		log.Fatal(err)
+	// Encode the image
+	if err = imageio.EncodeImage(cimg, outputFormat, out); err != nil {
+		return fmt.Errorf("failed to encode output image: %w", err)
 	}
 
 	return nil
 }
 
 func runDecode() error {
+	// Open input image
 	f, err := os.Open(decoderFlags.inputFile)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to open input image: %w", err)
 	}
+	defer f.Close()
 
-	src, err := png.Decode(bufio.NewReader(f))
+	// Detect and decode image format
+	src, _, err := imageio.DecodeImage(decoderFlags.inputFile, bufio.NewReader(f))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to decode image: %w", err)
 	}
 
+	// Decode the message
+	b, err := steg.Decode(toDrawImage(src), []byte(decoderFlags.key))
+	if err != nil {
+		return fmt.Errorf("decoding failed: %w", err)
+	}
+
+	// Write output file
 	out, err := os.Create(decoderFlags.outputFile)
 	if err != nil {
 		return fmt.Errorf("unable to create output file: %w", err)
 	}
 	defer out.Close()
 
-	b, err := steg.Decode(toDrawImage(src), []byte(decoderFlags.key))
-	if err != nil {
-		return err
-	}
-
-	_, err = out.Write(b)
-	if err != nil {
-		return err
+	if _, err = out.Write(b); err != nil {
+		return fmt.Errorf("failed to write output file: %w", err)
 	}
 
 	return nil

--- a/cmd/steg/root.go
+++ b/cmd/steg/root.go
@@ -60,8 +60,27 @@ var (
 	}
 
 	capacityFlags = struct {
-		inputImage string
+		inputImage     string
 		bitsPerChannel int
+	}{}
+
+	testVisualCmd = &cobra.Command{
+		Use:   "test-visual",
+		Short: "Generates test images with different channel and bit configurations",
+		Long:  "Generates multiple test images with all combinations of channels (1-max_channels) and bits per channel (1-max_bits) for visual comparison.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runTestVisual()
+		},
+	}
+
+	testVisualFlags = struct {
+		inputImage  string
+		outputDir   string
+		maxChannels int
+		maxBits     int
+		seed        int64
+		key         string
+		dataSize    int64 // Size of random data to encode in bytes (0 = use 80% of capacity)
 	}{}
 )
 
@@ -96,9 +115,32 @@ func init() {
 		&capacityFlags.bitsPerChannel, "bits_per_channel", "b", 1, "Number of bits per channel to use (1-3, default: 1).",
 	)
 
+	testVisualCmd.Flags().StringVarP(
+		&testVisualFlags.inputImage, "input_image", "i", "", "Input image used as medium.",
+	)
+	testVisualCmd.Flags().StringVarP(
+		&testVisualFlags.outputDir, "output_dir", "o", "", "Output directory for test images.",
+	)
+	testVisualCmd.Flags().IntVarP(
+		&testVisualFlags.maxChannels, "max_channels", "c", 3, "Maximum number of channels to test (1-3, default: 3).",
+	)
+	testVisualCmd.Flags().IntVarP(
+		&testVisualFlags.maxBits, "max_bits", "b", 3, "Maximum bits per channel to test (1-3, default: 3).",
+	)
+	testVisualCmd.Flags().Int64VarP(
+		&testVisualFlags.seed, "seed", "s", 42, "Seed for pseudo-random data generation (default: 42).",
+	)
+	testVisualCmd.Flags().StringVarP(
+		&testVisualFlags.key, "password", "p", "YELLOW SUBMARINE", "Password for encryption.",
+	)
+	testVisualCmd.Flags().Int64VarP(
+		&testVisualFlags.dataSize, "data_size", "d", 0, "Size of random data to encode in bytes (0 = use 80%% of capacity, default: 0).",
+	)
+
 	rootCmd.AddCommand(encodeCmd)
 	rootCmd.AddCommand(decodeCmd)
 	rootCmd.AddCommand(capacityCmd)
+	rootCmd.AddCommand(testVisualCmd)
 }
 
 func toDrawImage(src image.Image) draw.Image {
@@ -130,7 +172,7 @@ func runEncode() error {
 	}
 
 	cimg := toDrawImage(src)
-	
+
 	// Open message file
 	fmsg, err := os.Open(encoderFlags.inputMessage)
 	if err != nil {
@@ -231,7 +273,7 @@ func runCapacity() error {
 	// Get capacity in bits
 	capacityBits := cur.Capacity()
 	capacityBytes := capacityBits / 8
-	
+
 	// Calculate usable capacity (accounting for container overhead)
 	// Format overhead: 4 bytes (length) + 16 bytes (MD5 checksum) = 20 bytes
 	containerOverhead := int64(20)
@@ -250,7 +292,7 @@ func runCapacity() error {
 	fmt.Printf("Total capacity: %d bits (%d bytes)\n", capacityBits, capacityBytes)
 	fmt.Printf("Container overhead: %d bytes (length + checksum)\n", containerOverhead)
 	fmt.Printf("Usable capacity: %d bytes\n", usableBytes)
-	
+
 	// Display in human-readable format
 	if usableBytes > 0 {
 		fmt.Printf("\n")

--- a/cmd/steg/test_visual.go
+++ b/cmd/steg/test_visual.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/md5"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pableeee/steg/cipher"
+	"github.com/pableeee/steg/cursors"
+	"github.com/pableeee/steg/steg"
+	"github.com/pableeee/steg/steg/container"
+	"github.com/pableeee/steg/steg/imageio"
+)
+
+// getChannelOptions returns the appropriate cursor options for the given number of channels
+// Channels are selected in order: 1=G, 2=G+B, 3=R+G+B
+func getChannelOptions(numChannels int) []cursors.Option {
+	var opts []cursors.Option
+	switch numChannels {
+	case 1:
+		// Use Green channel only
+		opts = append(opts, cursors.UseGreenBit())
+	case 2:
+		// Use Green and Blue channels
+		opts = append(opts, cursors.UseGreenBit(), cursors.UseBlueBit())
+	case 3:
+		// Use all three channels (R, G, B)
+		// Since R_Bit is default and UseGreenBit/UseBlueBit use |=, 
+		// calling both gives us R|G|B which is what we want
+		opts = append(opts, cursors.UseGreenBit(), cursors.UseBlueBit())
+	}
+	return opts
+}
+
+// getChannelName returns a string representation of the channel configuration
+func getChannelName(numChannels int) string {
+	switch numChannels {
+	case 1:
+		return "G"
+	case 2:
+		return "GB"
+	case 3:
+		return "RGB"
+	default:
+		return fmt.Sprintf("%dch", numChannels)
+	}
+}
+
+func runTestVisual() error {
+	// Validate inputs
+	if testVisualFlags.inputImage == "" {
+		return fmt.Errorf("input_image is required")
+	}
+	if testVisualFlags.outputDir == "" {
+		return fmt.Errorf("output_dir is required")
+	}
+	if testVisualFlags.maxChannels < 1 || testVisualFlags.maxChannels > 3 {
+		return fmt.Errorf("max_channels must be between 1 and 3, got: %d", testVisualFlags.maxChannels)
+	}
+	if testVisualFlags.maxBits < 1 || testVisualFlags.maxBits > 3 {
+		return fmt.Errorf("max_bits must be between 1 and 3, got: %d", testVisualFlags.maxBits)
+	}
+
+	// Create output directory if it doesn't exist
+	if err := os.MkdirAll(testVisualFlags.outputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	// Open and decode input image
+	f, err := os.Open(testVisualFlags.inputImage)
+	if err != nil {
+		return fmt.Errorf("failed to open input image: %w", err)
+	}
+	defer f.Close()
+
+	src, _, err := imageio.DecodeImage(testVisualFlags.inputImage, bufio.NewReader(f))
+	if err != nil {
+		return fmt.Errorf("failed to decode image: %w", err)
+	}
+
+	// Get base filename without extension
+	baseName := strings.TrimSuffix(filepath.Base(testVisualFlags.inputImage), filepath.Ext(testVisualFlags.inputImage))
+
+	fmt.Printf("Generating test images for: %s\n", testVisualFlags.inputImage)
+	fmt.Printf("Output directory: %s\n", testVisualFlags.outputDir)
+	fmt.Printf("Configurations: %d channels × %d bits = %d images\n\n",
+		testVisualFlags.maxChannels, testVisualFlags.maxBits,
+		testVisualFlags.maxChannels*testVisualFlags.maxBits)
+
+	// Generate all combinations
+	for numChannels := 1; numChannels <= testVisualFlags.maxChannels; numChannels++ {
+		for bitsPerChannel := 1; bitsPerChannel <= testVisualFlags.maxBits; bitsPerChannel++ {
+			// Create a fresh copy of the image for this test
+			cimg := toDrawImage(src)
+
+			// Create cursor with this configuration for capacity calculation
+			opts := getChannelOptions(numChannels)
+			opts = append(opts, cursors.WithBitsPerChannel(bitsPerChannel))
+			opts = append(opts, cursors.WithSeed(testVisualFlags.seed))
+
+			cur := cursors.NewRNGCursor(cimg, opts...)
+
+			// Determine data size to encode
+			capacityBits := cur.Capacity()
+			capacityBytes := capacityBits / 8
+			containerOverhead := int64(20) // 4 bytes length + 16 bytes MD5
+			maxUsableBytes := capacityBytes - containerOverhead
+
+			var dataSize int64
+			if testVisualFlags.dataSize > 0 {
+				dataSize = testVisualFlags.dataSize
+				if dataSize > maxUsableBytes {
+					fmt.Printf("⚠️  Warning: Requested data size (%d bytes) exceeds capacity (%d bytes) for %dch-%dbit, using maximum\n",
+						dataSize, maxUsableBytes, numChannels, bitsPerChannel)
+					dataSize = maxUsableBytes
+				}
+			} else {
+				// Use 80% of capacity
+				dataSize = (maxUsableBytes * 80) / 100
+				if dataSize < 0 {
+					dataSize = 0
+				}
+			}
+
+			if dataSize <= 0 {
+				fmt.Printf("⏭️  Skipping %dch-%dbit: insufficient capacity\n", numChannels, bitsPerChannel)
+				continue
+			}
+
+			// Generate pseudo-random data with the specified seed
+			rng := rand.New(rand.NewSource(testVisualFlags.seed))
+			testData := make([]byte, dataSize)
+			for i := range testData {
+				testData[i] = byte(rng.Intn(256))
+			}
+
+			// Encode the data using the same seed derivation as regular encoding
+			seedVal, err := steg.DeriveSeedFromPassword([]byte(testVisualFlags.key))
+			if err != nil {
+				return fmt.Errorf("failed to derive seed: %w", err)
+			}
+
+			// Create cursor for encoding with password seed
+			encodeOpts := getChannelOptions(numChannels)
+			encodeOpts = append(encodeOpts, cursors.WithBitsPerChannel(bitsPerChannel))
+			encodeOpts = append(encodeOpts, cursors.WithSeed(seedVal))
+			encodeCur := cursors.NewRNGCursor(cimg, encodeOpts...)
+
+			// Validate capacity
+			hashFn := md5.New()
+			requiredBytes := container.CalculateRequiredCapacity(dataSize, hashFn.Size())
+			availableBytes := encodeCur.Capacity() / 8
+
+			if requiredBytes > availableBytes {
+				fmt.Printf("⚠️  Warning: %dch-%dbit capacity (%d bytes) insufficient for data (%d bytes), skipping\n",
+					numChannels, bitsPerChannel, availableBytes, requiredBytes)
+				continue
+			}
+
+			// Encode
+			cm := cursors.CipherMiddleware(encodeCur, cipher.NewCipher(0, []byte(testVisualFlags.key)))
+			adapter := cursors.CursorAdapter(cm)
+			if err := container.WritePayload(adapter, bytes.NewReader(testData), hashFn); err != nil {
+				return fmt.Errorf("failed to encode data for %dch-%dbit: %w", numChannels, bitsPerChannel, err)
+			}
+
+			// Generate output filename
+			channelName := getChannelName(numChannels)
+			outputFilename := fmt.Sprintf("%s_%s_%dbit.png", baseName, channelName, bitsPerChannel)
+			outputPath := filepath.Join(testVisualFlags.outputDir, outputFilename)
+
+			// Save the encoded image (always as PNG for consistency)
+			out, err := os.Create(outputPath)
+			if err != nil {
+				return fmt.Errorf("failed to create output file %s: %w", outputPath, err)
+			}
+
+			// Always save as PNG regardless of input format for consistency
+			if err := imageio.EncodeImage(cimg, imageio.FormatPNG, out); err != nil {
+				out.Close()
+				return fmt.Errorf("failed to encode image %s: %w", outputPath, err)
+			}
+			out.Close()
+
+			fmt.Printf("✓ Generated: %s (%d bytes encoded, %d bytes capacity)\n",
+				outputFilename, dataSize, capacityBytes)
+		}
+	}
+
+	fmt.Printf("\n✅ All test images generated successfully in: %s\n", testVisualFlags.outputDir)
+	return nil
+}

--- a/cursors/cursor.go
+++ b/cursors/cursor.go
@@ -4,6 +4,7 @@ type Cursor interface {
 	Seek(offset int64, whence int) (int64, error)
 	WriteBit(bit uint8) (uint, error)
 	ReadBit() (uint8, error)
+	Capacity() int64 // Returns available capacity in bits
 }
 
 type BitColor uint

--- a/cursors/middleware.go
+++ b/cursors/middleware.go
@@ -52,3 +52,7 @@ func (c *cipherMiddleware) ReadBit() (uint8, error) {
 
 	return b, err
 }
+
+func (c *cipherMiddleware) Capacity() int64 {
+	return c.next.Capacity()
+}

--- a/cursors/rng_cursor.go
+++ b/cursors/rng_cursor.go
@@ -12,6 +12,28 @@ import (
 const offLast = 0xfffe
 const justLast = 0x0001
 
+// getBitMask returns a mask for the LSBs based on bitsPerChannel
+func getBitMask(bitsPerChannel int) uint32 {
+	if bitsPerChannel <= 0 {
+		return justLast
+	}
+	if bitsPerChannel > 3 {
+		return 0x0007 // 3 bits max
+	}
+	return (1 << bitsPerChannel) - 1
+}
+
+// getClearMask returns a mask to clear the bits based on bitsPerChannel
+func getClearMask(bitsPerChannel int) uint32 {
+	if bitsPerChannel <= 0 {
+		return offLast
+	}
+	if bitsPerChannel > 3 {
+		return 0xfff8 // clear 3 bits max
+	}
+	return ^((1 << bitsPerChannel) - 1) | 0xffff0000 // Keep upper 16 bits from RGBA format
+}
+
 func generateSequence(width, height int, rng *rand.Rand) []image.Point {
 	totalPixels := width * height
 	positions := make([]image.Point, totalPixels)
@@ -31,13 +53,14 @@ func generateSequence(width, height int, rng *rand.Rand) []image.Point {
 }
 
 type RNGCursor struct {
-	img      draw.Image
-	cursor   int64
-	bitMask  BitColor
-	bitCount uint
-	useBits  []BitColor
-	points   []image.Point
-	rng      *rand.Rand
+	img            draw.Image
+	cursor         int64
+	bitMask        BitColor
+	bitCount       uint
+	useBits        []BitColor
+	points         []image.Point
+	rng            *rand.Rand
+	bitsPerChannel int // Number of bits to use per channel (1-3)
 }
 
 type Option func(*RNGCursor)
@@ -60,8 +83,26 @@ func WithSeed(seed int64) Option {
 	}
 }
 
+// WithBitsPerChannel sets the number of bits to use per color channel (1-3).
+// Default is 1 bit per channel. More bits increase capacity but may be more noticeable.
+func WithBitsPerChannel(n int) Option {
+	return func(c *RNGCursor) {
+		if n < 1 {
+			n = 1
+		} else if n > 3 {
+			n = 3
+		}
+		c.bitsPerChannel = n
+	}
+}
+
 func NewRNGCursor(img draw.Image, options ...Option) *RNGCursor {
-	c := &RNGCursor{img: img, bitMask: R_Bit, rng: rand.New(rand.NewSource(0))}
+	c := &RNGCursor{
+		img:            img,
+		bitMask:        R_Bit,
+		rng:            rand.New(rand.NewSource(0)),
+		bitsPerChannel: 1, // Default to 1 bit per channel
+	}
 	for _, opt := range options {
 		opt(c)
 	}
@@ -80,15 +121,23 @@ func NewRNGCursor(img draw.Image, options ...Option) *RNGCursor {
 var _ Cursor = (*RNGCursor)(nil)
 
 func (c *RNGCursor) validateBounds(n int64) bool {
-	max := int64(c.img.Bounds().Max.X) * int64(c.img.Bounds().Max.Y) * int64(c.bitCount)
-
+	max := c.Capacity()
 	return n < max
 }
 
-func (c *RNGCursor) tell() (x, y int, cl BitColor) {
+// Capacity returns the total capacity in bits available for encoding.
+func (c *RNGCursor) Capacity() int64 {
+	width := int64(c.img.Bounds().Max.X)
+	height := int64(c.img.Bounds().Max.Y)
+	return width * height * int64(c.bitCount) * int64(c.bitsPerChannel)
+}
 
-	planeCursor := c.cursor / int64(c.bitCount)
-	colorCursor := c.cursor % int64(c.bitCount)
+func (c *RNGCursor) tell() (x, y int, cl BitColor, bitPos int) {
+	bitsPerPixel := int64(c.bitCount) * int64(c.bitsPerChannel)
+	planeCursor := c.cursor / bitsPerPixel
+	remaining := c.cursor % bitsPerPixel
+	colorCursor := remaining / int64(c.bitsPerChannel)
+	bitPos = int(remaining % int64(c.bitsPerChannel))
 
 	x = c.points[planeCursor].X
 	y = c.points[planeCursor].Y
@@ -104,30 +153,34 @@ func (c *RNGCursor) Seek(n int64, whence int) (int64, error) {
 	// [SeekStart] means relative to the start of the file,
 	// [SeekCurrent] means relative to the current offset, and
 	// [SeekEnd] means relative to the end
-	if !c.validateBounds(n) {
-		return c.cursor, fmt.Errorf("out of bounds: %w", io.EOF)
-	}
+	var newPos int64
+	max := c.Capacity()
 
 	switch whence {
 	case io.SeekStart:
 		if n < 0 {
 			return c.cursor, fmt.Errorf("illegal argument")
 		}
-		c.cursor = n
+		newPos = n
 	case io.SeekCurrent:
 		if n < 0 && (n*-1) > c.cursor {
 			return c.cursor, fmt.Errorf("illegal argument")
 		}
-		c.cursor += n
+		newPos = c.cursor + n
 	case io.SeekEnd:
-		max := int64(c.img.Bounds().Max.X) * int64(c.img.Bounds().Max.Y) * int64(c.bitCount)
 		if n > 0 || (n*-1) > max {
 			return c.cursor, fmt.Errorf("illegal argument")
 		}
-
-		c.cursor = max + n
+		newPos = max + n
+	default:
+		return c.cursor, fmt.Errorf("invalid whence")
 	}
 
+	if newPos < 0 || newPos > max {
+		return c.cursor, fmt.Errorf("out of bounds: %w", io.EOF)
+	}
+
+	c.cursor = newPos
 	return c.cursor, nil
 }
 
@@ -136,27 +189,46 @@ func (c *RNGCursor) WriteBit(bit uint8) (uint, error) {
 		return uint(c.cursor), fmt.Errorf("out of bounds: %w", io.EOF)
 	}
 
-	fn := func(r *uint32) {
-		if bit == 1 {
-			*r = *r | justLast
-		} else {
-			*r = *r & offLast
-		}
-	}
-
-	x, y, colorBit := c.tell()
+	x, y, colorBit, bitPos := c.tell()
 
 	r, g, b, a := c.img.At(x, y).RGBA()
+	
+	// Convert RGBA (16-bit values) to 8-bit values
+	r8 := uint8(r >> 8)
+	g8 := uint8(g >> 8)
+	b8 := uint8(b >> 8)
+	a8 := uint8(a >> 8)
+
+	// Modify the appropriate channel
 	switch colorBit {
 	case R_Bit:
-		fn(&r)
+		// Clear the bit at the specific position
+		clearMask := ^(uint8(1) << bitPos)
+		r8 = r8 & clearMask
+		// Set the bit if needed
+		if bit == 1 {
+			setMask := uint8(1) << bitPos
+			r8 = r8 | setMask
+		}
 	case G_Bit:
-		fn(&g)
+		clearMask := ^(uint8(1) << bitPos)
+		g8 = g8 & clearMask
+		if bit == 1 {
+			setMask := uint8(1) << bitPos
+			g8 = g8 | setMask
+		}
 	case B_Bit:
-		fn(&b)
+		clearMask := ^(uint8(1) << bitPos)
+		b8 = b8 & clearMask
+		if bit == 1 {
+			setMask := uint8(1) << bitPos
+			b8 = b8 | setMask
+		}
+	default:
+		return uint(c.cursor), fmt.Errorf("invalid color bit")
 	}
 
-	c.img.Set(x, y, color.RGBA{uint8(r), uint8(g), uint8(b), uint8(a)})
+	c.img.Set(x, y, color.RGBA{r8, g8, b8, a8})
 
 	c.cursor++
 
@@ -167,11 +239,10 @@ func (c *RNGCursor) ReadBit() (uint8, error) {
 	if !c.validateBounds(c.cursor) {
 		return 0, fmt.Errorf("out of bounds")
 	}
-	x, y, colorBit := c.tell()
+	x, y, colorBit, bitPos := c.tell()
 	r, g, b, _ := c.img.At(x, y).RGBA()
-	c.cursor++
-	val := r
-
+	
+	var val uint32
 	switch colorBit {
 	case R_Bit:
 		val = r
@@ -179,9 +250,17 @@ func (c *RNGCursor) ReadBit() (uint8, error) {
 		val = g
 	case B_Bit:
 		val = b
+	default:
+		return 0, fmt.Errorf("invalid color bit")
 	}
 
-	bit := val & justLast
+	// Extract the 8-bit value (RGBA returns 16-bit values)
+	val8Bit := uint8(val >> 8)
+	
+	// Extract the bit at the specific position
+	bit := (val8Bit >> bitPos) & 1
 
-	return uint8(bit), nil
+	c.cursor++
+
+	return bit, nil
 }

--- a/docs/2025-12-20-FORMAT_SPECIFICATION.md
+++ b/docs/2025-12-20-FORMAT_SPECIFICATION.md
@@ -1,0 +1,295 @@
+# Steganography Format Specification
+
+This document describes the container format used by `steg` to store encoded data within images. It covers both the current format (Version 0) and the planned format with nonce support (Version 1).
+
+## Overview
+
+The steganographic data is stored in a container format within the image's pixel data. The format includes:
+- Length information (to know how much data to read)
+- The actual payload (encrypted)
+- A checksum for integrity verification
+
+All data is written bit-by-bit into the least significant bits (LSBs) of the image pixels, making the changes virtually imperceptible to the human eye.
+
+## Format Version 0 (Current - Backward Compatible)
+
+**Status**: Currently in use (default)
+
+### Layout
+
+```
+┌─────────────────┬──────────┬──────────────┐
+│  Length (4 B)   │  Payload │  Checksum    │
+│  (uint32 LE)    │  (N B)   │  (16 B MD5)  │
+└─────────────────┴──────────┴──────────────┘
+```
+
+### Byte Structure
+
+1. **Length (4 bytes, little-endian uint32)**
+   - Encrypted using AES-CTR stream cipher
+   - Specifies the size of the payload in bytes
+
+2. **Payload (N bytes)**
+   - The actual data being hidden
+   - Encrypted using AES-CTR stream cipher
+   - Size determined by the length field
+
+3. **Checksum (16 bytes)**
+   - MD5 hash of the decrypted payload
+   - Encrypted using AES-CTR stream cipher
+   - Used to verify data integrity and correct decryption
+
+### Encryption Details
+
+- **Cipher**: AES in CTR mode (stream cipher)
+- **Nonce**: Fixed value of `0` (security limitation)
+- **Key derivation**: PKCS#7 padded password → AES key
+- **Stream position**: The cipher uses the bit position within the stream as part of the counter
+
+### Example
+
+For a payload of `"hello"` (5 bytes):
+
+```
+[05 00 00 00] [encrypted "hello"] [16 encrypted MD5 bytes]
+   ↑              ↑                      ↑
+ Length        Payload              Checksum
+```
+
+### Total Size
+
+- **Minimum**: 4 (length) + 0 (empty payload) + 16 (MD5) = **20 bytes**
+- **Maximum**: Depends on image capacity (width × height × channels × bits_per_channel)
+
+---
+
+## Format Version 1 (Planned - With Nonce Support)
+
+**Status**: Infrastructure ready, but not yet activated (maintains backward compatibility)
+
+### Layout
+
+```
+┌────────┬───────────┬───────────┬──────────┬──────────────┐
+│ Nonce  │  Version  │  Length   │ Payload  │  Checksum    │
+│ (4 B)  │   (1 B)   │  (4 B)    │  (N B)   │  (16 B MD5)  │
+│        │           │ uint32 LE │          │              │
+└────────┴───────────┴───────────┴──────────┴──────────────┘
+   ↑         ↑          ↑           ↑           ↑
+ Unencrypted Encrypted  Encrypted   Encrypted   Encrypted
+```
+
+### Byte Structure
+
+1. **Nonce (4 bytes, unencrypted)**
+   - Cryptographically secure random 32-bit value
+   - Generated using `crypto/rand`
+   - Stored **unencrypted** at the start (needed to initialize cipher)
+   - Little-endian format
+
+2. **Version (1 byte)**
+   - Format version identifier
+   - Value: `0x01` for Version 1
+   - Encrypted using AES-CTR stream cipher (position starts after nonce)
+
+3. **Length (4 bytes, little-endian uint32)**
+   - Encrypted using AES-CTR stream cipher
+   - Specifies the size of the payload in bytes
+   - Cipher position continues from version byte
+
+4. **Payload (N bytes)**
+   - The actual data being hidden
+   - Encrypted using AES-CTR stream cipher
+   - Size determined by the length field
+
+5. **Checksum (16 bytes)**
+   - MD5 hash of the decrypted payload
+   - Encrypted using AES-CTR stream cipher
+   - Used to verify data integrity and correct decryption
+
+### Encryption Details
+
+- **Cipher**: AES in CTR mode (stream cipher)
+- **Nonce**: **Random per encoding session** (security improvement)
+- **Key derivation**: PKCS#7 padded password → AES key
+- **Stream position**: The cipher uses the bit position within the stream as part of the counter
+- **Nonce position**: Nonce is stored unencrypted at bit position 0-31 (byte 0-3)
+
+### Example
+
+For a payload of `"hello"` (5 bytes) with nonce `0x12345678`:
+
+```
+[78 56 34 12] [encrypted 0x01] [encrypted length] [encrypted "hello"] [encrypted MD5]
+     ↑              ↑                  ↑                   ↑                 ↑
+   Nonce        Version            Length             Payload          Checksum
+(unencrypted)   (encrypted)       (encrypted)        (encrypted)       (encrypted)
+```
+
+### Total Size
+
+- **Minimum**: 4 (nonce) + 1 (version) + 4 (length) + 0 (empty payload) + 16 (MD5) = **25 bytes**
+- **Maximum**: Depends on image capacity
+
+---
+
+## Key Differences
+
+| Aspect | Version 0 (Current) | Version 1 (Planned) |
+|--------|---------------------|---------------------|
+| **Nonce** | Fixed `0` | Random per encoding |
+| **Version field** | None (implicit) | 1 byte version identifier |
+| **Nonce storage** | Not stored (always 0) | Stored unencrypted at start |
+| **Security** | Lower (same nonce for all) | Higher (unique nonce per encoding) |
+| **Backward compatibility** | N/A (baseline) | Can decode Version 0 |
+| **Size overhead** | 20 bytes minimum | 25 bytes minimum (+5 bytes) |
+| **Format detection** | First 4 bytes = length | First 4 bytes = nonce, then version byte |
+
+## Security Implications
+
+### Version 0 Limitations
+
+Using a fixed nonce of `0` has security implications:
+
+1. **Replay vulnerability**: Multiple encodings with the same password produce similar ciphertext patterns
+2. **Statistical analysis**: Patterns may emerge when analyzing multiple encoded images
+3. **Reduced entropy**: The stream cipher initialization is predictable
+
+### Version 1 Benefits
+
+Using a random nonce per encoding provides:
+
+1. **Unique encryption**: Each encoding produces different ciphertext even with the same payload and password
+2. **Better security**: Follows cryptographic best practices for stream ciphers
+3. **Protection against**: Replay attacks, pattern analysis, and ciphertext comparison
+
+## Implementation Status
+
+### Current State
+
+The codebase includes:
+- ✅ Format version constants (`FormatVersion0`, `FormatVersion1`)
+- ✅ `GenerateNonce()` function for cryptographically secure nonce generation
+- ✅ `WritePayloadWithNonce()` function (infrastructure ready)
+- ✅ `ReadPayload()` function supporting Version 1 (infrastructure ready)
+- ✅ Backward compatibility layer (`ReadPayloadOldFormat()`)
+
+### Active Code
+
+Currently, the code uses:
+- `WritePayload()` - writes in Version 0 format
+- `ReadPayloadOldFormat()` - reads Version 0 format
+- Nonce value: `0` (hardcoded for compatibility)
+
+### Code Locations
+
+- **Container format**: `steg/container/container.go`
+- **Encoding**: `steg/encode.go` (uses `WritePayload()`)
+- **Decoding**: `steg/decode.go` (uses `ReadPayloadOldFormat()`)
+
+## Migration Path
+
+To activate Version 1 format:
+
+### Step 1: Update Encoding
+
+Modify `steg/encode.go`:
+```go
+// Generate random nonce
+nonce, err := container.GenerateNonce()
+if err != nil {
+    return fmt.Errorf("failed to generate nonce: %w", err)
+}
+
+// Write nonce unencrypted first
+adapterNoCipher := cursors.CursorAdapter(cur)
+nonceBytes := make([]byte, 4)
+binary.LittleEndian.PutUint32(nonceBytes, nonce)
+if _, err := adapterNoCipher.Write(nonceBytes); err != nil {
+    return fmt.Errorf("failed to write nonce: %w", err)
+}
+
+// Create cipher middleware with the generated nonce
+cm := cursors.CipherMiddleware(cur, cipher.NewCipher(nonce, pass))
+_, err = cm.Seek(32, 0) // Seek to position after nonce (32 bits = 4 bytes)
+if err != nil {
+    return fmt.Errorf("failed to seek cipher: %w", err)
+}
+
+adapter := cursors.CursorAdapter(cm)
+return container.WritePayloadWithNonce(adapter, bytes.NewReader(payloadData), hashFn, nonce)
+```
+
+### Step 2: Update Decoding
+
+Modify `steg/decode.go`:
+```go
+// Read nonce unencrypted from first 4 bytes
+adapterNoCipher := cursors.CursorAdapter(cur)
+nonceBytes := make([]byte, 4)
+_, err = adapterNoCipher.Read(nonceBytes)
+if err != nil {
+    // Fallback to Version 0 (try nonce=0)
+    return decodeVersion0(m, pass)
+}
+nonce := binary.LittleEndian.Uint32(nonceBytes)
+
+// Create cipher middleware with the extracted nonce
+cm := cursors.CipherMiddleware(cur, cipher.NewCipher(nonce, pass))
+_, err = cm.Seek(32, 0) // Seek to position after nonce
+if err != nil {
+    return nil, fmt.Errorf("failed to seek cipher: %w", err)
+}
+
+adapter := cursors.CursorAdapter(cm)
+payload, _, err := container.ReadPayload(adapter, md5.New())
+// ... handle errors and fallback to Version 0
+```
+
+### Step 3: Update Capacity Calculation
+
+Modify `container.CalculateRequiredCapacity()` to account for the nonce:
+```go
+func CalculateRequiredCapacity(payloadSize int64, hashSize int) int64 {
+    // Version 1: 4 (nonce) + 1 (version) + 4 (length) + payload + checksum
+    return 4 + 1 + 4 + payloadSize + int64(hashSize)
+}
+```
+
+### Step 4: Testing
+
+- Test encoding/decoding with Version 1
+- Test backward compatibility (decoding Version 0 images)
+- Test format detection and fallback logic
+- Update tests to cover both formats
+
+## Compatibility Considerations
+
+### Version Detection
+
+When reading:
+1. Read first 4 bytes (could be nonce or length)
+2. Try to read version byte
+3. If version byte exists and equals `0x01` → Version 1
+4. If no version byte or value doesn't match → Version 0 (fallback)
+
+### Backward Compatibility
+
+- **Version 1 decoder must** be able to decode Version 0 images
+- **Version 0 decoder cannot** decode Version 1 images (won't have nonce)
+- **Migration strategy**: Keep both decoders active, detect format automatically
+
+## Future Enhancements
+
+Potential improvements:
+- Format version 2: Support for different hash algorithms (not just MD5)
+- Format version 3: Support for different encryption algorithms
+- Format version 4: Metadata header (encoding date, tool version, etc.)
+
+## References
+
+- Container format implementation: `steg/container/container.go`
+- Cipher implementation: `cipher/cipher.go`
+- Encoding logic: `steg/encode.go`
+- Decoding logic: `steg/decode.go`

--- a/mocks/cursors/cursor.go
+++ b/mocks/cursors/cursor.go
@@ -5,89 +5,10 @@
 package mock_cursors
 
 import (
-	image "image"
-	color "image/color"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
 )
-
-// MockChangeableImage is a mock of ChangeableImage interface.
-type MockChangeableImage struct {
-	ctrl     *gomock.Controller
-	recorder *MockChangeableImageMockRecorder
-}
-
-// MockChangeableImageMockRecorder is the mock recorder for MockChangeableImage.
-type MockChangeableImageMockRecorder struct {
-	mock *MockChangeableImage
-}
-
-// NewMockChangeableImage creates a new mock instance.
-func NewMockChangeableImage(ctrl *gomock.Controller) *MockChangeableImage {
-	mock := &MockChangeableImage{ctrl: ctrl}
-	mock.recorder = &MockChangeableImageMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockChangeableImage) EXPECT() *MockChangeableImageMockRecorder {
-	return m.recorder
-}
-
-// At mocks base method.
-func (m *MockChangeableImage) At(x, y int) color.Color {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "At", x, y)
-	ret0, _ := ret[0].(color.Color)
-	return ret0
-}
-
-// At indicates an expected call of At.
-func (mr *MockChangeableImageMockRecorder) At(x, y interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "At", reflect.TypeOf((*MockChangeableImage)(nil).At), x, y)
-}
-
-// Bounds mocks base method.
-func (m *MockChangeableImage) Bounds() image.Rectangle {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bounds")
-	ret0, _ := ret[0].(image.Rectangle)
-	return ret0
-}
-
-// Bounds indicates an expected call of Bounds.
-func (mr *MockChangeableImageMockRecorder) Bounds() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bounds", reflect.TypeOf((*MockChangeableImage)(nil).Bounds))
-}
-
-// ColorModel mocks base method.
-func (m *MockChangeableImage) ColorModel() color.Model {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ColorModel")
-	ret0, _ := ret[0].(color.Model)
-	return ret0
-}
-
-// ColorModel indicates an expected call of ColorModel.
-func (mr *MockChangeableImageMockRecorder) ColorModel() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ColorModel", reflect.TypeOf((*MockChangeableImage)(nil).ColorModel))
-}
-
-// Set mocks base method.
-func (m *MockChangeableImage) Set(x, y int, c color.Color) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Set", x, y, c)
-}
-
-// Set indicates an expected call of Set.
-func (mr *MockChangeableImageMockRecorder) Set(x, y, c interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockChangeableImage)(nil).Set), x, y, c)
-}
 
 // MockCursor is a mock of Cursor interface.
 type MockCursor struct {
@@ -110,6 +31,20 @@ func NewMockCursor(ctrl *gomock.Controller) *MockCursor {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCursor) EXPECT() *MockCursorMockRecorder {
 	return m.recorder
+}
+
+// Capacity mocks base method.
+func (m *MockCursor) Capacity() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Capacity")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// Capacity indicates an expected call of Capacity.
+func (mr *MockCursorMockRecorder) Capacity() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Capacity", reflect.TypeOf((*MockCursor)(nil).Capacity))
 }
 
 // ReadBit mocks base method.
@@ -155,18 +90,4 @@ func (m *MockCursor) WriteBit(bit uint8) (uint, error) {
 func (mr *MockCursorMockRecorder) WriteBit(bit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteBit", reflect.TypeOf((*MockCursor)(nil).WriteBit), bit)
-}
-
-// Capacity mocks base method.
-func (m *MockCursor) Capacity() int64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Capacity")
-	ret0, _ := ret[0].(int64)
-	return ret0
-}
-
-// Capacity indicates an expected call of Capacity.
-func (mr *MockCursorMockRecorder) Capacity() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Capacity", reflect.TypeOf((*MockCursor)(nil).Capacity))
 }

--- a/mocks/cursors/cursor.go
+++ b/mocks/cursors/cursor.go
@@ -156,3 +156,17 @@ func (mr *MockCursorMockRecorder) WriteBit(bit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteBit", reflect.TypeOf((*MockCursor)(nil).WriteBit), bit)
 }
+
+// Capacity mocks base method.
+func (m *MockCursor) Capacity() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Capacity")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// Capacity indicates an expected call of Capacity.
+func (mr *MockCursorMockRecorder) Capacity() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Capacity", reflect.TypeOf((*MockCursor)(nil).Capacity))
+}

--- a/steg/container/container.go
+++ b/steg/container/container.go
@@ -1,13 +1,38 @@
 package container
 
 import (
+	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"hash"
 	"io"
 )
 
+const (
+	// Format version constants
+	FormatVersion0 = 0 // Old format: [4-byte length][payload][checksum], nonce=0
+	FormatVersion1 = 1 // New format: [1-byte version][4-byte nonce][4-byte length][payload][checksum]
+)
+
+// CalculateRequiredCapacity calculates the total capacity needed in bytes
+// for encoding a payload of the given size.
+// Format: [4-byte length][payload][hash-size checksum]
+func CalculateRequiredCapacity(payloadSize int64, hashSize int) int64 {
+	return 4 + payloadSize + int64(hashSize)
+}
+
+// GenerateNonce generates a cryptographically secure random 32-bit nonce
+func GenerateNonce() (uint32, error) {
+	nonceBytes := make([]byte, 4)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		return 0, err
+	}
+	return uint32(nonceBytes[0]) | uint32(nonceBytes[1])<<8 | uint32(nonceBytes[2])<<16 | uint32(nonceBytes[3])<<24, nil
+}
+
+// WritePayload writes a payload in the old format (version 0) for backward compatibility
 func WritePayload(w io.WriteSeeker, payload io.Reader, hashFn hash.Hash) error {
+	// Old format: [4-byte length][payload][checksum]
 	// Reserve space for length (4 bytes)
 	_, err := w.Seek(4, io.SeekStart)
 	if err != nil {
@@ -53,7 +78,63 @@ func WritePayload(w io.WriteSeeker, payload io.Reader, hashFn hash.Hash) error {
 	return err
 }
 
-func ReadPayload(r io.ReadWriteSeeker, hashFn hash.Hash) ([]byte, error) {
+// WritePayloadWithNonce writes a payload with format version 1 (nonce is already written separately)
+func WritePayloadWithNonce(w io.WriteSeeker, payload io.Reader, hashFn hash.Hash, nonce uint32) error {
+	// Format version 1: [1-byte version][4-byte length][payload][checksum]
+	// Note: nonce is written separately before this function is called
+	
+	// Write format version (1 byte)
+	versionByte := []byte{FormatVersion1}
+	if _, err := w.Write(versionByte); err != nil {
+		return fmt.Errorf("failed to write format version: %w", err)
+	}
+
+	// Reserve space for length (4 bytes)
+	if _, err := w.Seek(4, io.SeekCurrent); err != nil {
+		return err
+	}
+
+	var length uint32
+	buf := make([]byte, 1024)
+	for {
+		n, readErr := payload.Read(buf)
+		if n > 0 {
+			hashFn.Write(buf[:n])
+			_, writeErr := w.Write(buf[:n])
+			if writeErr != nil {
+				return writeErr
+			}
+			length += uint32(n)
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+
+	// Write the hash
+	checksum := hashFn.Sum(nil)
+	_, err := w.Write(checksum)
+	if err != nil {
+		return err
+	}
+
+	// Go back and write the length (after version byte)
+	_, err = w.Seek(1, io.SeekStart) // After version byte
+	if err != nil {
+		return err
+	}
+
+	sizeBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(sizeBytes, length)
+	_, err = w.Write(sizeBytes)
+	return err
+}
+
+// ReadPayloadOldFormat reads a payload in the old format (version 0, no nonce)
+func ReadPayloadOldFormat(r io.ReadWriteSeeker, hashFn hash.Hash) ([]byte, error) {
 	sizeBytes := make([]byte, 4)
 	_, err := io.ReadFull(r, sizeBytes)
 	if err != nil {
@@ -79,6 +160,51 @@ func ReadPayload(r io.ReadWriteSeeker, hashFn hash.Hash) ([]byte, error) {
 	}
 
 	return payload, nil
+}
+
+// ReadPayload reads a payload in the new format (version 1, with nonce).
+// The nonce should already be read separately (unencrypted).
+// Returns payload, nonce (for verification), and error.
+func ReadPayload(r io.ReadWriteSeeker, hashFn hash.Hash) ([]byte, uint32, error) {
+	// Read format version (1 byte, encrypted)
+	versionByte := make([]byte, 1)
+	_, err := io.ReadFull(r, versionByte)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read format version: %w", err)
+	}
+
+	version := versionByte[0]
+	if version != FormatVersion1 {
+		return nil, 0, fmt.Errorf("unexpected format version: %d (expected %d)", version, FormatVersion1)
+	}
+
+	// Read length (4 bytes, encrypted)
+	sizeBytes := make([]byte, 4)
+	_, err = io.ReadFull(r, sizeBytes)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read payload size: %w", err)
+	}
+
+	length := binary.LittleEndian.Uint32(sizeBytes)
+	payload := make([]byte, length)
+	_, err = io.ReadFull(r, payload)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read payload: %w", err)
+	}
+	hashFn.Write(payload)
+
+	checksum := make([]byte, hashFn.Size())
+	_, err = io.ReadFull(r, checksum)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read checksum: %w", err)
+	}
+
+	if !bytesEqual(checksum, hashFn.Sum(nil)) {
+		return nil, 0, fmt.Errorf("checksum validation failed")
+	}
+
+	// Return 0 as nonce - it's passed separately for verification
+	return payload, 0, nil
 }
 
 func bytesEqual(a, b []byte) bool {

--- a/steg/container/container_test.go
+++ b/steg/container/container_test.go
@@ -23,7 +23,7 @@ func TestContainerRoundTrip(t *testing.T) {
 	// Reset seek to start of stream
 	buf.Seek(0, io.SeekStart)
 
-	readData, err := container.ReadPayload(buf, md5.New())
+	readData, err := container.ReadPayloadOldFormat(buf, md5.New())
 	require.NoError(t, err)
 	assert.Equal(t, payload, readData)
 }
@@ -36,7 +36,7 @@ func TestEmptyPayload(t *testing.T) {
 	require.NoError(t, err)
 
 	buf.Seek(0, io.SeekStart)
-	readData, err := container.ReadPayload(buf, md5.New())
+	readData, err := container.ReadPayloadOldFormat(buf, md5.New())
 	require.NoError(t, err)
 	assert.Empty(t, readData)
 }
@@ -55,7 +55,7 @@ func TestChecksumMismatch(t *testing.T) {
 	buf.Write([]byte{corruptedData})
 
 	buf.Seek(0, io.SeekStart)
-	_, err = container.ReadPayload(buf, md5.New())
+	_, err = container.ReadPayloadOldFormat(buf, md5.New())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "checksum")
 }
@@ -72,7 +72,7 @@ func TestTruncatedData(t *testing.T) {
 	assert.NoError(t, err)
 
 	buf.Seek(0, io.SeekStart)
-	_, err = container.ReadPayload(buf, md5.New())
+	_, err = container.ReadPayloadOldFormat(buf, md5.New())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read")
 }
@@ -90,7 +90,7 @@ func TestExcessiveLength(t *testing.T) {
 	buf.Write([]byte{0xFF, 0xFF, 0xFF, 0x7F})
 
 	buf.Seek(0, io.SeekStart)
-	_, err = container.ReadPayload(buf, md5.New())
+	_, err = container.ReadPayloadOldFormat(buf, md5.New())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read payload")
 }

--- a/steg/decode.go
+++ b/steg/decode.go
@@ -11,7 +11,7 @@ import (
 
 func Decode(m draw.Image, pass []byte) ([]byte, error) {
 	// Derive a seed from the password
-	seedVal, err := deriveSeedFromPassword(pass)
+	seedVal, err := DeriveSeedFromPassword(pass)
 	if err != nil {
 		return nil, err
 	}

--- a/steg/decode.go
+++ b/steg/decode.go
@@ -24,12 +24,12 @@ func Decode(m draw.Image, pass []byte) ([]byte, error) {
 		cursors.WithSeed(seedVal),
 	)
 
-	// Create cipher middleware
+	// Create cipher middleware (using nonce=0 for backward compatibility)
 	cm := cursors.CipherMiddleware(cur, cipher.NewCipher(0, pass))
 
 	// CursorAdapter transforms a Cursor into an io.ReadWriteSeeker
 	adapter := cursors.CursorAdapter(cm)
 
-	// Use container to read payload: length + payload + checksum verification
-	return container.ReadPayload(adapter, md5.New())
+	// Use container to read payload: length + payload + checksum verification (old format)
+	return container.ReadPayloadOldFormat(adapter, md5.New())
 }

--- a/steg/encode.go
+++ b/steg/encode.go
@@ -20,7 +20,7 @@ func Encode(m draw.Image, pass []byte, r io.Reader) error {
 	}
 
 	// Derive a seed from the password
-	seedVal, err := deriveSeedFromPassword(pass)
+	seedVal, err := DeriveSeedFromPassword(pass)
 	if err != nil {
 		return err
 	}
@@ -50,7 +50,7 @@ func Encode(m draw.Image, pass []byte, r io.Reader) error {
 	// Note: For now, we use nonce=0 to maintain format compatibility
 	// TODO: Implement proper nonce storage in container format for full security
 	nonce := uint32(0) // Maintain old format for backward compatibility
-	
+
 	// Create cipher middleware with nonce (currently 0 for compatibility)
 	cm := cursors.CipherMiddleware(cur, cipher.NewCipher(nonce, pass))
 

--- a/steg/encode.go
+++ b/steg/encode.go
@@ -1,7 +1,9 @@
 package steg
 
 import (
+	"bytes"
 	"crypto/md5"
+	"fmt"
 	"image/draw"
 	"io"
 
@@ -11,6 +13,12 @@ import (
 )
 
 func Encode(m draw.Image, pass []byte, r io.Reader) error {
+	// Read the entire payload into memory to determine its size for capacity validation
+	payloadData, err := io.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("failed to read payload: %w", err)
+	}
+
 	// Derive a seed from the password
 	seedVal, err := deriveSeedFromPassword(pass)
 	if err != nil {
@@ -25,12 +33,30 @@ func Encode(m draw.Image, pass []byte, r io.Reader) error {
 		cursors.WithSeed(seedVal),
 	)
 
-	// Create cipher middleware
-	cm := cursors.CipherMiddleware(cur, cipher.NewCipher(0, pass))
+	// Validate capacity before encoding
+	hashFn := md5.New()
+	requiredBytes := container.CalculateRequiredCapacity(int64(len(payloadData)), hashFn.Size())
+	availableBits := cur.Capacity()
+	availableBytes := availableBits / 8
+
+	if requiredBytes > availableBytes {
+		return &ErrInsufficientCapacity{
+			RequiredBytes:  requiredBytes,
+			AvailableBytes: availableBytes,
+		}
+	}
+
+	// Generate random nonce for encryption (improves security vs fixed nonce=0)
+	// Note: For now, we use nonce=0 to maintain format compatibility
+	// TODO: Implement proper nonce storage in container format for full security
+	nonce := uint32(0) // Maintain old format for backward compatibility
+	
+	// Create cipher middleware with nonce (currently 0 for compatibility)
+	cm := cursors.CipherMiddleware(cur, cipher.NewCipher(nonce, pass))
 
 	// CursorAdapter transforms a Cursor into an io.ReadWriteSeeker
 	adapter := cursors.CursorAdapter(cm)
 
-	// Use container to write payload: length + payload + checksum
-	return container.WritePayload(adapter, r, md5.New())
+	// Use container to write payload: length + payload + checksum (old format)
+	return container.WritePayload(adapter, bytes.NewReader(payloadData), hashFn)
 }

--- a/steg/errors.go
+++ b/steg/errors.go
@@ -1,0 +1,26 @@
+package steg
+
+import "fmt"
+
+// ErrInsufficientCapacity is returned when the image doesn't have enough space
+// to encode the payload.
+type ErrInsufficientCapacity struct {
+	RequiredBytes int64
+	AvailableBytes int64
+}
+
+func (e *ErrInsufficientCapacity) Error() string {
+	return fmt.Sprintf("insufficient capacity: need %d bytes, have %d bytes (required: %.2f%% more capacity)", 
+		e.RequiredBytes, e.AvailableBytes, 
+		float64(e.RequiredBytes-e.AvailableBytes)*100.0/float64(e.AvailableBytes))
+}
+
+// ErrInvalidFormat is returned when the image format is not supported or invalid.
+type ErrInvalidFormat struct {
+	Format string
+	Reason string
+}
+
+func (e *ErrInvalidFormat) Error() string {
+	return fmt.Sprintf("invalid image format '%s': %s", e.Format, e.Reason)
+}

--- a/steg/imageio/format.go
+++ b/steg/imageio/format.go
@@ -1,0 +1,121 @@
+package imageio
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/jpeg"
+	"image/png"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/pableeee/steg/steg"
+)
+
+// ImageFormat represents supported image formats
+type ImageFormat string
+
+const (
+	FormatPNG ImageFormat = "png"
+	FormatJPEG ImageFormat = "jpeg"
+	FormatUnknown ImageFormat = "unknown"
+)
+
+// DetectImageFormat detects the image format from file extension or magic bytes
+func DetectImageFormat(filename string, file io.Reader) (ImageFormat, error) {
+	// First try extension
+	ext := strings.ToLower(filename)
+	if strings.HasSuffix(ext, ".png") {
+		return FormatPNG, nil
+	}
+	if strings.HasSuffix(ext, ".jpg") || strings.HasSuffix(ext, ".jpeg") {
+		return FormatJPEG, nil
+	}
+
+	// Try magic bytes
+	magicBytes := make([]byte, 8)
+	if f, ok := file.(*os.File); ok {
+		pos, _ := f.Seek(0, io.SeekCurrent)
+		defer f.Seek(pos, io.SeekStart)
+		n, _ := f.Read(magicBytes)
+		f.Seek(pos, io.SeekStart)
+		if n >= 8 {
+			if bytes.HasPrefix(magicBytes, []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}) {
+				return FormatPNG, nil
+			}
+			if bytes.HasPrefix(magicBytes, []byte{0xFF, 0xD8, 0xFF}) {
+				return FormatJPEG, nil
+			}
+		}
+	} else {
+		// For generic readers, try to read magic bytes
+		peekBytes := make([]byte, 8)
+		readSeeker, ok := file.(io.ReadSeeker)
+		if ok {
+			pos, _ := readSeeker.Seek(0, io.SeekCurrent)
+			defer readSeeker.Seek(pos, io.SeekStart)
+			n, _ := readSeeker.Read(peekBytes)
+			readSeeker.Seek(pos, io.SeekStart)
+			if n >= 3 {
+				if bytes.HasPrefix(peekBytes, []byte{0x89, 0x50, 0x4E, 0x47}) {
+					return FormatPNG, nil
+				}
+				if bytes.HasPrefix(peekBytes, []byte{0xFF, 0xD8, 0xFF}) {
+					return FormatJPEG, nil
+				}
+			}
+		}
+	}
+
+	return FormatUnknown, fmt.Errorf("unable to detect image format")
+}
+
+// DecodeImage decodes an image from a reader using format detection
+func DecodeImage(filename string, file io.Reader) (image.Image, ImageFormat, error) {
+	format, err := DetectImageFormat(filename, file)
+	if err != nil {
+		return nil, FormatUnknown, err
+	}
+
+	var img image.Image
+	switch format {
+	case FormatPNG:
+		img, err = png.Decode(file)
+	case FormatJPEG:
+		img, err = jpeg.Decode(file)
+	default:
+		return nil, FormatUnknown, &steg.ErrInvalidFormat{
+			Format: string(format),
+			Reason: "format not supported for decoding",
+		}
+	}
+
+	if err != nil {
+		return nil, format, fmt.Errorf("failed to decode %s image: %w", format, err)
+	}
+
+	return img, format, nil
+}
+
+// EncodeImage encodes an image to a writer in the specified format
+func EncodeImage(img image.Image, format ImageFormat, w io.Writer) error {
+	switch format {
+	case FormatPNG:
+		return png.Encode(w, img)
+	case FormatJPEG:
+		// Use quality 95 for JPEG to minimize compression artifacts
+		// Note: JPEG is lossy and may corrupt steganographic data
+		return jpeg.Encode(w, img, &jpeg.Options{Quality: 95})
+	default:
+		return &steg.ErrInvalidFormat{
+			Format: string(format),
+			Reason: "format not supported for encoding",
+		}
+	}
+}
+
+// IsLossyFormat returns true if the format uses lossy compression
+func IsLossyFormat(format ImageFormat) bool {
+	return format == FormatJPEG
+}

--- a/steg/steg.go
+++ b/steg/steg.go
@@ -4,8 +4,8 @@ import (
 	"crypto/md5"
 )
 
-// deriveSeedFromPassword takes a password and returns a reproducible int64 seed.
-func deriveSeedFromPassword(pass []byte) (int64, error) {
+// DeriveSeedFromPassword takes a password and returns a reproducible int64 seed.
+func DeriveSeedFromPassword(pass []byte) (int64, error) {
 	hashFn := md5.New()
 	if _, err := hashFn.Write(pass); err != nil {
 		return 0, err


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces multi-bit-per-channel encoding with capacity APIs, PNG/JPEG image I/O, new capacity and visual test CLI commands, and container v1 (nonce/version) scaffolding while keeping v0 active.
> 
> - **Core encoding/decoding**:
>   - `cursors.RNGCursor`: supports multiple bits per channel (1–3), shuffled traversal, `Capacity()`; updated `Seek`/`ReadBit`/`WriteBit` to address per-bit positions.
>   - `cursors.Cursor` interface gains `Capacity()`; middleware/mocks updated to proxy/mock it.
>   - `steg.Encode`/`Decode`: export `DeriveSeedFromPassword`, add capacity validation with `ErrInsufficientCapacity`; still use nonce `0` and old container format for compatibility.
> - **Container format**:
>   - Add `FormatVersion0/1`, `GenerateNonce()`, `CalculateRequiredCapacity()`.
>   - New v1 helpers: `WritePayloadWithNonce()` and `ReadPayload()`; keep v0 via `WritePayload()` and `ReadPayloadOldFormat()`; tests updated to v0 reader.
> - **CLI** (`cmd/steg`):
>   - New `capacity` command to report usable bytes (supports configurable `bits_per_channel`).
>   - New `test-visual` command to generate images across channel/bit combos with seeded data.
>   - `encode`/`decode` now use `steg/imageio` for PNG/JPEG detection/encoding and warn on lossy formats.
> - **Image I/O**:
>   - New `steg/imageio` with format detection (`png`/`jpeg`), encoding, and `IsLossyFormat()`.
> - **Docs**:
>   - Add `FORMAT_SPECIFICATION.md` and dated doc detailing v0 and planned v1 (nonce/version) container formats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed4db69349aa4e18f80d28d0ad9fc4291f5381d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->