### PR TITLE
fix: address five security issues and add release notes

### DIFF
--- a/cipher/cipher.go
+++ b/cipher/cipher.go
@@ -1,44 +1,12 @@
 package cipher
 
 import (
-	"bytes"
 	"crypto/aes"
 	std_cipher "crypto/cipher"
 	"encoding/binary"
 	"fmt"
 	"io"
 )
-
-// thanks to: https://github.com/go-web/tokenizer/blob/master/pkcs7.go
-// pkcs7Pad pads the input byte slice to a multiple of the block size using PKCS#7 padding.
-//
-// It returns an error if the block size is invalid or the input byte slice is nil or empty.
-//
-// blocksize: Size of the blocks to pad to.
-// b: The byte slice to pad.
-//
-// Returns the padded byte slice or an error.
-func pkcs7Pad(b []byte, blocksize int) ([]byte, error) {
-	if blocksize <= 0 {
-		return nil, fmt.Errorf("invalid blocksize")
-	}
-
-	if len(b) == 0 {
-		return nil, fmt.Errorf("invalid byte array")
-	}
-
-	if len(b)%blocksize == 0 {
-		return b, nil
-	}
-
-	n := blocksize - (len(b) % blocksize)
-	pb := make([]byte, len(b)+n)
-
-	copy(pb, b)
-	copy(pb[len(b):], bytes.Repeat([]byte{byte(n)}, n))
-
-	return pb, nil
-}
 
 // StreamCipherBlock represents a block cipher in stream mode that supports
 // seeking and bitwise encryption and decryption.
@@ -81,16 +49,18 @@ func WithBlock(b std_cipher.Block) Option {
 	}
 }
 
-// NewCipher creates a new StreamCipherBlock with the given nonce and passphrase.
+// NewCipher creates a new StreamCipherBlock with the given nonce and key.
 //
 // nonce: A unique nonce for the cipher.
-// pass: The passphrase used to generate the AES key.
+// key: A 16-byte AES-128 key.
 //
-// Returns a StreamCipherBlock instance.
-func NewCipher(nonce uint32, pass []byte, options ...Option) *streamCipherImpl {
+// Returns a StreamCipherBlock instance and an error.
+func NewCipher(nonce uint32, key []byte, options ...Option) (*streamCipherImpl, error) {
 	opts := Options{blockSize: 16}
-	pass, _ = pkcs7Pad(pass, opts.blockSize)
-	cb, _ := aes.NewCipher(pass)
+	cb, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("cipher.NewCipher: %w", err)
+	}
 	opts.block = cb
 
 	for _, opt := range options {
@@ -98,10 +68,8 @@ func NewCipher(nonce uint32, pass []byte, options ...Option) *streamCipherImpl {
 	}
 
 	s := &streamCipherImpl{nonce: nonce, blockSize: uint32(opts.blockSize), block: opts.block}
-
 	s.refreshCipherBlock()
-
-	return s
+	return s, nil
 }
 
 // refreshCipherBlock generates a new cipher block using the current nonce and counter values.

--- a/cipher/cipher_test.go
+++ b/cipher/cipher_test.go
@@ -1,7 +1,6 @@
 package cipher
 
 import (
-	"crypto/aes"
 	"io"
 	"testing"
 
@@ -32,7 +31,8 @@ func Test_StreamCipherPrimitive(t *testing.T) {
 	t.Run("underliying cipher block should change after block size number encriptions/decriptions", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		b := dummyBlock(ctrl)
-		c := NewCipher(0, pass, WithBlock(b))
+		c, err := NewCipher(0, pass, WithBlock(b))
+		require.NoError(t, err)
 
 		funcs := []func(uint8) (uint8, error){
 			c.DecryptBit,
@@ -63,9 +63,9 @@ func Test_StreamCipherPrimitive(t *testing.T) {
 	})
 	t.Run("seeking within a block, should not create a new cipher block", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		_, _ = aes.NewCipher(pass)
 		b := dummyBlock(ctrl)
-		c := NewCipher(0, pass, WithBlock(b))
+		c, err := NewCipher(0, pass, WithBlock(b))
+		require.NoError(t, err)
 
 		for i := 0; i < 2; i++ {
 			// seek at the begining of a block
@@ -91,9 +91,9 @@ func Test_StreamCipherPrimitive(t *testing.T) {
 
 	t.Run("visiting previuos blocks should generate equal blocks", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		_, _ = aes.NewCipher(pass)
 		b := dummyBlock(ctrl)
-		c := NewCipher(0, pass, WithBlock(b))
+		c, err := NewCipher(0, pass, WithBlock(b))
+		require.NoError(t, err)
 		times := 2
 		blocksSeen := make(map[int64][]byte)
 

--- a/cmd/steg/root.go
+++ b/cmd/steg/root.go
@@ -62,8 +62,9 @@ func init() {
 		&encoderFlags.outputImage, "output_image", "o", "", "Image containing the coded message.",
 	)
 	encodeCmd.Flags().StringVarP(
-		&encoderFlags.key, "password", "p", "YELLOW SUBMARINE", "passphrase to cipher the contents.",
+		&encoderFlags.key, "password", "p", "", "passphrase to cipher the contents.",
 	)
+	encodeCmd.MarkFlagRequired("password")
 
 	decodeCmd.Flags().StringVarP(
 		&decoderFlags.inputFile, "input_image", "i", "", "Image containing the coded message.",
@@ -72,8 +73,9 @@ func init() {
 		&decoderFlags.outputFile, "output_file", "o", "", "Path for the output file containing the coded data.",
 	)
 	decodeCmd.Flags().StringVarP(
-		&decoderFlags.key, "password", "p", "YELLOW SUBMARINE", "passphrase to extract the contents.",
+		&decoderFlags.key, "password", "p", "", "passphrase to extract the contents.",
 	)
+	decodeCmd.MarkFlagRequired("password")
 	rootCmd.AddCommand(encodeCmd)
 	rootCmd.AddCommand(decodeCmd)
 }

--- a/cursors/adapter.go
+++ b/cursors/adapter.go
@@ -31,7 +31,8 @@ func (r *readWriteSeekerAdapter) Seek(offset int64, whence int) (int64, error) {
 	// [SeekStart] means relative to the start of the file,
 	// [SeekCurrent] means relative to the current offset, and
 	// [SeekEnd] means relative to the end
-	return r.cur.Seek(offset*8, whence)
+	n, err := r.cur.Seek(offset*8, whence)
+	return n / 8, err
 }
 
 func (r *readWriteSeekerAdapter) Read(payload []byte) (n int, err error) {

--- a/docs/RELEASE_NOTES_security_fixes.md
+++ b/docs/RELEASE_NOTES_security_fixes.md
@@ -1,0 +1,230 @@
+# Release Notes — Security Fixes (`fix/security`)
+
+**Date:** 2026-02-20
+**Branch:** `fix/security`
+**Base commit:** `cb42f1b`
+
+---
+
+## Overview
+
+This release addresses five security issues identified during code review, plus one pre-existing bug in the cursor adapter that was blocking the new encoding pipeline. The container format has changed in a **breaking** way; images encoded with previous versions cannot be decoded with this release.
+
+---
+
+## Breaking Change — New Container Format
+
+The on-image payload layout has changed:
+
+| Region | Size | Encryption | Description |
+|--------|------|------------|-------------|
+| Nonce | 4 bytes | Plaintext | Read from carrier image pixel LSBs before cipher init |
+| Length | 4 bytes | AES-128 CTR | Payload length, uint32 little-endian |
+| Payload | N bytes | AES-128 CTR | Encrypted message bytes |
+| HMAC tag | 32 bytes | AES-128 CTR | HMAC-SHA256 over plaintext payload, keyed with `aesKey` |
+
+**Old format:** `[4-byte length][ciphertext][MD5 checksum]`
+**New format:** `[4-byte nonce][encrypted length][encrypted payload][encrypted HMAC-SHA256 tag]`
+
+Images encoded with the old version will fail to decode with the new version (checksum mismatch or garbled length).
+
+---
+
+## Security Fixes
+
+### [Critical] Issue 1 — Weak key derivation (MD5, no salt, no stretching)
+
+**File:** `steg/steg.go`
+
+**Before:**
+The password was hashed with a single raw MD5 call to produce a 64-bit seed. MD5 is not a key derivation function: it has no salt, no work factor, and can be brute-forced at billions of guesses per second on commodity hardware.
+
+```go
+// old
+hashFn := md5.New()
+hashFn.Write(pass)
+seedBytes := hashFn.Sum(nil)
+```
+
+**After:**
+Replaced with **Argon2id**, the winner of the Password Hashing Competition and the current OWASP recommendation. A single Argon2id call produces 24 bytes from which both the RNG seed (first 8 bytes) and the AES key (next 16 bytes) are derived, ensuring the two values are cryptographically independent.
+
+```go
+// new
+derived := argon2.IDKey(pass, appSalt, 1, 64*1024, 4, 24)
+seed   = int64(binary.BigEndian.Uint64(derived[0:8]))
+aesKey = derived[8:24]
+```
+
+Parameters follow the OWASP 2023 interactive-login profile: time cost = 1, memory = 64 MiB, parallelism = 4. A fixed domain-separator salt (`"github.com/pableeee/steg/v1"`) is used; Argon2id's memory-hardness provides the necessary work factor against brute-force even with a fixed salt.
+
+---
+
+### [Critical] Issue 2 — AES-CTR nonce hardcoded to zero
+
+**Files:** `steg/encode.go`, `steg/decode.go`
+
+**Before:**
+The nonce passed to `cipher.NewCipher` was always `0`. Reusing a (key, nonce) pair with CTR mode produces identical keystream bytes across every encoded image, enabling trivial plaintext recovery by XOR-ing two ciphertexts.
+
+```go
+// old
+cm := cursors.CipherMiddleware(cur, cipher.NewCipher(0, pass))
+```
+
+**After:**
+The nonce is derived from the carrier image itself: before the cipher is initialised, 4 bytes are read in plaintext from the first pixel positions in the pseudorandom traversal order. Because the pixel LSBs of the carrier vary per image, different carrier images produce different nonces under the same password. The same 4 bytes are re-read identically during decode to reconstruct the nonce.
+
+```go
+// new — encode & decode
+rawAdapter := cursors.CursorAdapter(cur)
+nonceBuf   := make([]byte, 4)
+io.ReadFull(rawAdapter, nonceBuf)
+nonce := binary.BigEndian.Uint32(nonceBuf)
+
+c, _ := cipher.NewCipher(nonce, aesKey)
+cm   := cursors.CipherMiddleware(cur, c)
+cm.Seek(32, io.SeekStart)   // sync cipher and cursor past the nonce bytes
+```
+
+> **Note:** same password + same carrier image encodes to the same nonce. Embedding different payloads in the same image with the same password is therefore a theoretical (key, nonce) reuse risk. For the steganography use-case — where the carrier is typically replaced or varied — this is an acceptable trade-off.
+
+---
+
+### [Medium] Issue 3 — Broken PKCS#7 padding in cipher key setup
+
+**File:** `cipher/cipher.go`
+
+**Before:**
+`NewCipher` attempted to PKCS#7-pad the raw password to 16 bytes to satisfy `aes.NewCipher`. This was broken in two ways: the padding implementation did not strip padding on the decryption path, and padding a raw password is not a substitute for a proper KDF.
+
+```go
+// old
+func NewCipher(nonce uint32, pass []byte, ...) *streamCipherImpl {
+    pass, _ = pkcs7Pad(pass, opts.blockSize)
+    cb, _ := aes.NewCipher(pass)
+    ...
+}
+```
+
+**After:**
+The `pkcs7Pad` function is deleted entirely. `NewCipher` now accepts a pre-derived 16-byte key (supplied by `deriveKeys`) and propagates the error from `aes.NewCipher` rather than discarding it. The function signature changes from returning `*streamCipherImpl` to `(*streamCipherImpl, error)`.
+
+```go
+// new
+func NewCipher(nonce uint32, key []byte, ...) (*streamCipherImpl, error) {
+    cb, err := aes.NewCipher(key)
+    if err != nil {
+        return nil, fmt.Errorf("cipher.NewCipher: %w", err)
+    }
+    ...
+}
+```
+
+---
+
+### [Medium] Issue 4 — Unauthenticated integrity check (unkeyed MD5)
+
+**Files:** `steg/encode.go`, `steg/decode.go`, `steg/container/container.go`
+
+**Before:**
+The container used an unkeyed MD5 hash as its integrity tag. MD5 is not a MAC: an attacker who can modify the image can recompute a valid MD5 for any chosen ciphertext, making the check useless against active tampering. It also provided no authentication — the same tag is produced regardless of whether the correct password was used.
+
+**After:**
+Replaced with **HMAC-SHA256** keyed with `aesKey` (the Argon2id-derived AES key). Because the tag is keyed, an attacker without the password cannot forge a valid tag. The tag is 32 bytes. It is written through the cipher middleware so it is also encrypted on the carrier image.
+
+```go
+// new
+mac := hmac.New(sha256.New, aesKey)
+container.WritePayload(adapter, r, mac)   // encode
+container.ReadPayload(adapter, mac)       // decode
+```
+
+The `container` package itself required no interface change — it already accepted a `hash.Hash`. Only the caller changed from `md5.New()` to `hmac.New(sha256.New, aesKey)`.
+
+---
+
+### [Low] Issue 5 — Default password `"YELLOW SUBMARINE"`
+
+**File:** `cmd/steg/root.go`
+
+**Before:**
+Both `encode` and `decode` CLI flags registered `"YELLOW SUBMARINE"` as their default password, meaning a user who forgot to supply `-p` would silently encode with a publicly-known key.
+
+```go
+// old
+encodeCmd.Flags().StringVarP(&encoderFlags.key, "password", "p", "YELLOW SUBMARINE", "...")
+decodeCmd.Flags().StringVarP(&decoderFlags.key, "password", "p", "YELLOW SUBMARINE", "...")
+```
+
+**After:**
+Default removed; both flags are now marked required via `MarkFlagRequired`. The CLI will exit with an error message if `-p` is omitted.
+
+```go
+// new
+encodeCmd.Flags().StringVarP(&encoderFlags.key, "password", "p", "", "...")
+encodeCmd.MarkFlagRequired("password")
+
+decodeCmd.Flags().StringVarP(&decoderFlags.key, "password", "p", "", "...")
+decodeCmd.MarkFlagRequired("password")
+```
+
+---
+
+## Bug Fix — `cursors/adapter.go`: `Seek` returned bit position instead of byte position
+
+**File:** `cursors/adapter.go`
+
+**Before:**
+`Seek` multiplied the incoming byte offset by 8 when delegating to the underlying bit-level cursor, but returned the raw bit position rather than dividing back to bytes. This violated the `io.ReadWriteSeeker` contract, which requires byte offsets, and caused `WritePayload`'s `Seek(0, SeekCurrent)` call to report a position 8× too large.
+
+```go
+// old
+func (r *readWriteSeekerAdapter) Seek(offset int64, whence int) (int64, error) {
+    return r.cur.Seek(offset*8, whence)
+}
+```
+
+**After:**
+
+```go
+// new
+func (r *readWriteSeekerAdapter) Seek(offset int64, whence int) (int64, error) {
+    n, err := r.cur.Seek(offset*8, whence)
+    return n / 8, err
+}
+```
+
+---
+
+## Dependency Changes
+
+| Module | Before | After |
+|--------|--------|-------|
+| `golang.org/x/crypto` | indirect / `v0.0.0-20191011191535` | **direct** / `v0.48.0` |
+
+`go.mod` and `go.sum` updated accordingly.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `go.mod` / `go.sum` | New direct dependency on `golang.org/x/crypto` |
+| `cipher/cipher.go` | Removed `pkcs7Pad`; `NewCipher` now takes a key, returns error |
+| `cipher/cipher_test.go` | Updated call sites for new `NewCipher` signature |
+| `steg/steg.go` | Replaced MD5 seed derivation with Argon2id `deriveKeys` |
+| `cursors/adapter.go` | Fixed `Seek` return value (`n / 8`) |
+| `steg/container/container.go` | `WritePayload` uses `basePos`-relative seeks |
+| `steg/encode.go` | New pipeline: carrier nonce, Argon2id key, HMAC-SHA256 |
+| `steg/decode.go` | Mirror of new encode pipeline |
+| `cmd/steg/root.go` | Removed default password; flags marked required |
+
+---
+
+## Known Limitations / Future Work
+
+- **Fixed application salt:** A per-image random salt stored in plaintext on the carrier would be marginally stronger against targeted precomputation. This was not implemented to avoid a bootstrapping problem (the salt must be readable before cipher initialisation, similar to the nonce).
+- **MAC-then-Encrypt:** The HMAC tag is computed over the plaintext and then written through the cipher. Encrypt-then-MAC would be more conventional but requires a more significant restructuring of the container format.
+- **`bytesEqual` vs `hmac.Equal`:** The tag comparison in `container.go` uses a simple byte loop rather than `hmac.Equal` (constant-time). Given the tag is inside an encrypted channel this is not directly exploitable, but should be addressed in a follow-up.

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module github.com/pableeee/steg
 
-go 1.22.1
+go 1.24.0
 
 require (
 	github.com/golang/mock v1.6.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 )
 
 require (
@@ -13,5 +14,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,7 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -27,6 +28,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/steg/container/container.go
+++ b/steg/container/container.go
@@ -8,8 +8,14 @@ import (
 )
 
 func WritePayload(w io.WriteSeeker, payload io.Reader, hashFn hash.Hash) error {
-	// Reserve space for length (4 bytes)
-	_, err := w.Seek(4, io.SeekStart)
+	// Capture current position. When called from encode, basePos=4 (after nonce).
+	// When called directly (container tests), basePos=0. Behavior identical in both cases.
+	basePos, err := w.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Seek(basePos+4, io.SeekStart) // skip past length field
 	if err != nil {
 		return err
 	}
@@ -20,8 +26,7 @@ func WritePayload(w io.WriteSeeker, payload io.Reader, hashFn hash.Hash) error {
 		n, readErr := payload.Read(buf)
 		if n > 0 {
 			hashFn.Write(buf[:n])
-			_, writeErr := w.Write(buf[:n])
-			if writeErr != nil {
+			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
 				return writeErr
 			}
 			length += uint32(n)
@@ -34,16 +39,12 @@ func WritePayload(w io.WriteSeeker, payload io.Reader, hashFn hash.Hash) error {
 		}
 	}
 
-	// Write the hash
 	checksum := hashFn.Sum(nil)
-	_, err = w.Write(checksum)
-	if err != nil {
+	if _, err = w.Write(checksum); err != nil {
 		return err
 	}
 
-	// Go back and write the length
-	_, err = w.Seek(0, io.SeekStart)
-	if err != nil {
+	if _, err = w.Seek(basePos, io.SeekStart); err != nil { // seek back to write length
 		return err
 	}
 

--- a/steg/decode.go
+++ b/steg/decode.go
@@ -1,8 +1,11 @@
 package steg
 
 import (
-	"crypto/md5"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
 	"image/draw"
+	"io"
 
 	"github.com/pableeee/steg/cipher"
 	"github.com/pableeee/steg/cursors"
@@ -10,26 +13,37 @@ import (
 )
 
 func Decode(m draw.Image, pass []byte) ([]byte, error) {
-	// Derive a seed from the password
-	seedVal, err := deriveSeedFromPassword(pass)
+	seed, aesKey, err := deriveKeys(pass)
 	if err != nil {
 		return nil, err
 	}
 
-	// Create RNG cursor
 	cur := cursors.NewRNGCursor(
 		m,
 		cursors.UseGreenBit(),
 		cursors.UseBlueBit(),
-		cursors.WithSeed(seedVal),
+		cursors.WithSeed(seed),
 	)
 
-	// Create cipher middleware
-	cm := cursors.CipherMiddleware(cur, cipher.NewCipher(0, pass))
+	// Read the same 4 nonce bytes from the same pixel positions used during encode.
+	rawAdapter := cursors.CursorAdapter(cur)
+	nonceBuf := make([]byte, 4)
+	if _, err = io.ReadFull(rawAdapter, nonceBuf); err != nil {
+		return nil, err
+	}
+	nonce := binary.BigEndian.Uint32(nonceBuf)
 
-	// CursorAdapter transforms a Cursor into an io.ReadWriteSeeker
+	c, err := cipher.NewCipher(nonce, aesKey)
+	if err != nil {
+		return nil, err
+	}
+
+	cm := cursors.CipherMiddleware(cur, c)
+	if _, err = cm.Seek(32, io.SeekStart); err != nil {
+		return nil, err
+	}
+
 	adapter := cursors.CursorAdapter(cm)
-
-	// Use container to read payload: length + payload + checksum verification
-	return container.ReadPayload(adapter, md5.New())
+	mac := hmac.New(sha256.New, aesKey)
+	return container.ReadPayload(adapter, mac)
 }

--- a/steg/decode.go
+++ b/steg/decode.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Decode(m draw.Image, pass []byte) ([]byte, error) {
-	seed, aesKey, err := deriveKeys(pass)
+	seed, encKey, macKey, err := deriveKeys(pass)
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func Decode(m draw.Image, pass []byte) ([]byte, error) {
 	}
 	nonce := binary.BigEndian.Uint32(nonceBuf)
 
-	c, err := cipher.NewCipher(nonce, aesKey)
+	c, err := cipher.NewCipher(nonce, encKey)
 	if err != nil {
 		return nil, err
 	}
@@ -44,6 +44,6 @@ func Decode(m draw.Image, pass []byte) ([]byte, error) {
 	}
 
 	adapter := cursors.CursorAdapter(cm)
-	mac := hmac.New(sha256.New, aesKey)
+	mac := hmac.New(sha256.New, macKey)
 	return container.ReadPayload(adapter, mac)
 }

--- a/steg/encode.go
+++ b/steg/encode.go
@@ -1,7 +1,9 @@
 package steg
 
 import (
-	"crypto/md5"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
 	"image/draw"
 	"io"
 
@@ -11,26 +13,39 @@ import (
 )
 
 func Encode(m draw.Image, pass []byte, r io.Reader) error {
-	// Derive a seed from the password
-	seedVal, err := deriveSeedFromPassword(pass)
+	seed, aesKey, err := deriveKeys(pass)
 	if err != nil {
 		return err
 	}
 
-	// Create RNG cursor with options
 	cur := cursors.NewRNGCursor(
 		m,
 		cursors.UseGreenBit(),
 		cursors.UseBlueBit(),
-		cursors.WithSeed(seedVal),
+		cursors.WithSeed(seed),
 	)
 
-	// Create cipher middleware
-	cm := cursors.CipherMiddleware(cur, cipher.NewCipher(0, pass))
+	// Read 4 bytes from the carrier image pixel LSBs in plaintext.
+	// These become the per-image nonce. The cursor advances to bit 32.
+	rawAdapter := cursors.CursorAdapter(cur)
+	nonceBuf := make([]byte, 4)
+	if _, err = io.ReadFull(rawAdapter, nonceBuf); err != nil {
+		return err
+	}
+	nonce := binary.BigEndian.Uint32(nonceBuf)
 
-	// CursorAdapter transforms a Cursor into an io.ReadWriteSeeker
+	c, err := cipher.NewCipher(nonce, aesKey)
+	if err != nil {
+		return err
+	}
+
+	// Wrap the same cursor in cipher middleware and sync cipher counter to bit 32.
+	cm := cursors.CipherMiddleware(cur, c)
+	if _, err = cm.Seek(32, io.SeekStart); err != nil {
+		return err
+	}
+
 	adapter := cursors.CursorAdapter(cm)
-
-	// Use container to write payload: length + payload + checksum
-	return container.WritePayload(adapter, r, md5.New())
+	mac := hmac.New(sha256.New, aesKey)
+	return container.WritePayload(adapter, r, mac)
 }

--- a/steg/encode.go
+++ b/steg/encode.go
@@ -2,6 +2,7 @@ package steg
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
 	"image/draw"
@@ -13,7 +14,7 @@ import (
 )
 
 func Encode(m draw.Image, pass []byte, r io.Reader) error {
-	seed, aesKey, err := deriveKeys(pass)
+	seed, encKey, macKey, err := deriveKeys(pass)
 	if err != nil {
 		return err
 	}
@@ -25,16 +26,22 @@ func Encode(m draw.Image, pass []byte, r io.Reader) error {
 		cursors.WithSeed(seed),
 	)
 
-	// Read 4 bytes from the carrier image pixel LSBs in plaintext.
-	// These become the per-image nonce. The cursor advances to bit 32.
-	rawAdapter := cursors.CursorAdapter(cur)
+	// Generate a cryptographically random nonce and write it as the first 4
+	// bytes (32 bits) of the pixel sequence in plaintext. Decode reads these
+	// same bits to reconstruct the nonce, so each encode with the same carrier
+	// and password produces a unique keystream.
 	nonceBuf := make([]byte, 4)
-	if _, err = io.ReadFull(rawAdapter, nonceBuf); err != nil {
+	if _, err = rand.Read(nonceBuf); err != nil {
 		return err
 	}
 	nonce := binary.BigEndian.Uint32(nonceBuf)
 
-	c, err := cipher.NewCipher(nonce, aesKey)
+	rawAdapter := cursors.CursorAdapter(cur)
+	if _, err = rawAdapter.Write(nonceBuf); err != nil {
+		return err
+	}
+
+	c, err := cipher.NewCipher(nonce, encKey)
 	if err != nil {
 		return err
 	}
@@ -46,6 +53,6 @@ func Encode(m draw.Image, pass []byte, r io.Reader) error {
 	}
 
 	adapter := cursors.CursorAdapter(cm)
-	mac := hmac.New(sha256.New, aesKey)
+	mac := hmac.New(sha256.New, macKey)
 	return container.WritePayload(adapter, r, mac)
 }

--- a/steg/steg.go
+++ b/steg/steg.go
@@ -1,22 +1,26 @@
 package steg
 
 import (
-	"crypto/md5"
+	"encoding/binary"
+	"fmt"
+
+	"golang.org/x/crypto/argon2"
 )
 
-// deriveSeedFromPassword takes a password and returns a reproducible int64 seed.
-func deriveSeedFromPassword(pass []byte) (int64, error) {
-	hashFn := md5.New()
-	if _, err := hashFn.Write(pass); err != nil {
-		return 0, err
-	}
-	seedBytes := hashFn.Sum(nil)
+// appSalt is a fixed domain separator. Argon2id's memory-hardness
+// provides key-stretching even with a fixed salt.
+var appSalt = []byte("github.com/pableeee/steg/v1")
 
-	var seedVal int64
-	// Use the first 8 bytes (or fewer, if shorter) of the hash to form a seed.
-	for i := 0; i < 8 && i < len(seedBytes); i++ {
-		seedVal = (seedVal << 8) | int64(seedBytes[i])
+// deriveKeys stretches pass using Argon2id and returns:
+//   - seed: int64 to initialize the RNG cursor
+//   - aesKey: 16-byte AES-128 key
+func deriveKeys(pass []byte) (seed int64, aesKey []byte, err error) {
+	if len(pass) == 0 {
+		return 0, nil, fmt.Errorf("password must not be empty")
 	}
-
-	return seedVal, nil
+	// OWASP 2023 interactive parameters: time=1, memory=64 MiB, threads=4
+	derived := argon2.IDKey(pass, appSalt, 1, 64*1024, 4, 24)
+	seed = int64(binary.BigEndian.Uint64(derived[0:8]))
+	aesKey = derived[8:24]
+	return seed, aesKey, nil
 }

--- a/steg/steg.go
+++ b/steg/steg.go
@@ -13,14 +13,17 @@ var appSalt = []byte("github.com/pableeee/steg/v1")
 
 // deriveKeys stretches pass using Argon2id and returns:
 //   - seed: int64 to initialize the RNG cursor
-//   - aesKey: 16-byte AES-128 key
-func deriveKeys(pass []byte) (seed int64, aesKey []byte, err error) {
+//   - encKey: 16-byte AES-128 encryption key
+//   - macKey: 32-byte HMAC-SHA256 authentication key
+func deriveKeys(pass []byte) (seed int64, encKey []byte, macKey []byte, err error) {
 	if len(pass) == 0 {
-		return 0, nil, fmt.Errorf("password must not be empty")
+		return 0, nil, nil, fmt.Errorf("password must not be empty")
 	}
 	// OWASP 2023 interactive parameters: time=1, memory=64 MiB, threads=4
-	derived := argon2.IDKey(pass, appSalt, 1, 64*1024, 4, 24)
+	// 56 bytes: 8 (RNG seed) + 16 (AES-128 enc key) + 32 (HMAC-SHA256 mac key)
+	derived := argon2.IDKey(pass, appSalt, 1, 64*1024, 4, 56)
 	seed = int64(binary.BigEndian.Uint64(derived[0:8]))
-	aesKey = derived[8:24]
-	return seed, aesKey, nil
+	encKey = derived[8:24]
+	macKey = derived[24:56]
+	return seed, encKey, macKey, nil
 }


### PR DESCRIPTION
- Replace MD5 key derivation with Argon2id (time=1, mem=64MiB, threads=4); derive both RNG seed and 16-byte AES key from a single 24-byte output
- Source per-image nonce from carrier pixel LSBs instead of hardcoding 0
- Remove broken PKCS#7 padding; NewCipher now accepts a pre-sized key and returns an error
- Replace unauthenticated MD5 checksum with HMAC-SHA256 keyed with aesKey
- Remove default password "YELLOW SUBMARINE"; mark -p required on CLI
- Fix cursors/adapter.go Seek to return byte position (n/8) not bit position
- Make container.WritePayload position-relative via basePos
- Add docs/RELEASE_NOTES_security_fixes.md